### PR TITLE
DO NOT MERGE: Replace FilesDir with fs.FS

### DIFF
--- a/base/util/file.go
+++ b/base/util/file.go
@@ -15,22 +15,14 @@
 package util
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/coreos/fcct/config/common"
 )
 
-func EnsurePathWithinFilesDir(path, filesDir string) error {
-	absBase, err := filepath.Abs(filesDir)
-	if err != nil {
-		return err
-	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
+func EnsurePathWithinFS(name string) error {
+	if name = path.Clean(name); strings.HasPrefix(name, "..") {
 		return common.ErrFilesDirEscape
 	}
 	return nil

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -25,6 +25,7 @@ import (
 
 	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/internal/fsutil"
 	"github.com/coreos/fcct/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -209,7 +210,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// inline file contents
@@ -266,7 +267,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// filesDir not specified
@@ -302,7 +303,7 @@ func TestTranslateFile(t *testing.T) {
 			[]translate.Translation{},
 			"error at $.contents.local: " + common.ErrFilesDirEscape.Error() + "\n",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// attempted inclusion of nonexistent file
@@ -321,7 +322,7 @@ func TestTranslateFile(t *testing.T) {
 			[]translate.Translation{},
 			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": no such file or directory\n",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// inline and local automatic file encoding
@@ -424,7 +425,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// Test disable automatic gzip compression
@@ -1295,7 +1296,7 @@ func TestTranslateTree(t *testing.T) {
 			},
 		}
 		options := common.TranslateOptions{
-			FilesDir: filesDir,
+			FS: fsutil.DirFS(filesDir),
 		}
 		if test.options != nil {
 			options = *test.options

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -16,14 +16,15 @@ package v0_3
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
+	"io/fs"
+	gopath "path"
 	"path/filepath"
 	"strings"
 	"text/template"
 
 	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/internal/fsutil"
 	"github.com/coreos/fcct/translate"
 
 	"github.com/coreos/go-systemd/unit"
@@ -133,20 +134,18 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Local != nil {
 		c := path.New("yaml", "local")
 
-		if options.FilesDir == "" {
+		if options.FS == nil {
 			r.AddOnError(c, common.ErrNoFilesDir)
 			return
 		}
 
-		// calculate file path within FilesDir and check for
-		// path traversal
-		filePath := filepath.Join(options.FilesDir, *from.Local)
-		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
+		filePath := gopath.Clean(*from.Local)
+		if err := baseutil.EnsurePathWithinFS(filePath); err != nil {
 			r.AddOnError(c, err)
 			return
 		}
 
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := fs.ReadFile(options.FS, filePath)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -216,19 +215,18 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 
 	for i, tree := range c.Storage.Trees {
 		yamlPath := path.New("yaml", "storage", "trees", i)
-		if options.FilesDir == "" {
+		if options.FS == nil {
 			r.AddOnError(yamlPath, common.ErrNoFilesDir)
 			return ts, r
 		}
 
-		// calculate base path within FilesDir and check for
-		// path traversal
-		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
-		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
+		srcBaseDir := gopath.Clean(tree.Local)
+		if err := baseutil.EnsurePathWithinFS(srcBaseDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
 		}
-		info, err := os.Stat(srcBaseDir)
+
+		info, err := fsutil.Stat(options.FS, srcBaseDir)
 		if err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
@@ -251,7 +249,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 	// The strategy for errors within WalkFunc is to add an error to
 	// the report and return nil, so walking continues but translation
 	// will fail afterward.
-	err := filepath.Walk(srcBaseDir, func(srcPath string, info os.FileInfo, err error) error {
+	err := fs.WalkDir(options.FS, srcBaseDir, func(srcPath string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			r.AddOnError(yamlPath, err)
 			return nil
@@ -263,9 +261,11 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 		}
 		destPath := filepath.Join(destBaseDir, relPath)
 
-		if info.Mode().IsDir() {
+		switch typ := entry.Type(); {
+		case typ.IsDir():
 			return nil
-		} else if info.Mode().IsRegular() {
+
+		case typ.IsRegular():
 			i, file := t.GetFile(destPath)
 			if file != nil {
 				if file.Contents.Source != nil && *file.Contents.Source != "" {
@@ -287,7 +287,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "files"))
 				}
 			}
-			contents, err := ioutil.ReadFile(srcPath)
+			contents, err := fs.ReadFile(options.FS, srcPath)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil
@@ -305,13 +305,18 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 			}
 			if file.Mode == nil {
 				mode := 0644
-				if info.Mode()&0111 != 0 {
+				if info, err := entry.Info(); err != nil {
+					r.AddOnError(yamlPath, err)
+					return nil
+				} else if info.Mode().Perm()&0111 != 0 {
 					mode = 0755
 				}
 				file.Mode = &mode
 				ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "mode"))
 			}
-		} else if info.Mode()&os.ModeType == os.ModeSymlink {
+			return nil
+
+		case typ&fs.ModeType == fs.ModeSymlink:
 			i, link := t.GetLink(destPath)
 			if link != nil {
 				if link.Target != "" {
@@ -333,17 +338,18 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "links"))
 				}
 			}
-			link.Target, err = os.Readlink(srcPath)
+			link.Target, err = fsutil.ReadLink(options.FS, srcPath)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
 			ts.AddTranslation(yamlPath, path.New("json", "storage", "links", i, "target"))
-		} else {
+			return nil
+
+		default:
 			r.AddOnError(yamlPath, common.ErrFileType)
 			return nil
 		}
-		return nil
 	})
 	r.AddOnError(yamlPath, err)
 }

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -25,6 +25,7 @@ import (
 
 	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/internal/fsutil"
 	"github.com/coreos/fcct/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -209,7 +210,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// inline file contents
@@ -266,7 +267,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// filesDir not specified
@@ -302,7 +303,7 @@ func TestTranslateFile(t *testing.T) {
 			[]translate.Translation{},
 			"error at $.contents.local: " + common.ErrFilesDirEscape.Error() + "\n",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// attempted inclusion of nonexistent file
@@ -321,7 +322,7 @@ func TestTranslateFile(t *testing.T) {
 			[]translate.Translation{},
 			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": no such file or directory\n",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// inline and local automatic file encoding
@@ -424,7 +425,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// Test disable automatic gzip compression
@@ -1375,7 +1376,7 @@ func TestTranslateTree(t *testing.T) {
 			},
 		}
 		options := common.TranslateOptions{
-			FilesDir: filesDir,
+			FS: fsutil.DirFS(filesDir),
 		}
 		if test.options != nil {
 			options = *test.options

--- a/base/v0_4_exp/translate.go
+++ b/base/v0_4_exp/translate.go
@@ -16,14 +16,15 @@ package v0_4_exp
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
+	"io/fs"
+	gopath "path"
 	"path/filepath"
 	"strings"
 	"text/template"
 
 	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/internal/fsutil"
 	"github.com/coreos/fcct/translate"
 
 	"github.com/coreos/go-systemd/unit"
@@ -147,20 +148,18 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Local != nil {
 		c := path.New("yaml", "local")
 
-		if options.FilesDir == "" {
+		if options.FS == nil {
 			r.AddOnError(c, common.ErrNoFilesDir)
 			return
 		}
 
-		// calculate file path within FilesDir and check for
-		// path traversal
-		filePath := filepath.Join(options.FilesDir, *from.Local)
-		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
+		filePath := gopath.Clean(*from.Local)
+		if err := baseutil.EnsurePathWithinFS(filePath); err != nil {
 			r.AddOnError(c, err)
 			return
 		}
 
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := fs.ReadFile(options.FS, filePath)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -230,19 +229,18 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 
 	for i, tree := range c.Storage.Trees {
 		yamlPath := path.New("yaml", "storage", "trees", i)
-		if options.FilesDir == "" {
+		if options.FS == nil {
 			r.AddOnError(yamlPath, common.ErrNoFilesDir)
 			return ts, r
 		}
 
-		// calculate base path within FilesDir and check for
-		// path traversal
-		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
-		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
+		srcBaseDir := gopath.Clean(tree.Local)
+		if err := baseutil.EnsurePathWithinFS(srcBaseDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
 		}
-		info, err := os.Stat(srcBaseDir)
+
+		info, err := fsutil.Stat(options.FS, srcBaseDir)
 		if err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
@@ -265,7 +263,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 	// The strategy for errors within WalkFunc is to add an error to
 	// the report and return nil, so walking continues but translation
 	// will fail afterward.
-	err := filepath.Walk(srcBaseDir, func(srcPath string, info os.FileInfo, err error) error {
+	err := fs.WalkDir(options.FS, srcBaseDir, func(srcPath string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			r.AddOnError(yamlPath, err)
 			return nil
@@ -277,9 +275,11 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 		}
 		destPath := filepath.Join(destBaseDir, relPath)
 
-		if info.Mode().IsDir() {
+		switch typ := entry.Type(); {
+		case typ.IsDir():
 			return nil
-		} else if info.Mode().IsRegular() {
+
+		case typ.IsRegular():
 			i, file := t.GetFile(destPath)
 			if file != nil {
 				if file.Contents.Source != nil && *file.Contents.Source != "" {
@@ -301,7 +301,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "files"))
 				}
 			}
-			contents, err := ioutil.ReadFile(srcPath)
+			contents, err := fs.ReadFile(options.FS, srcPath)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil
@@ -319,13 +319,18 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 			}
 			if file.Mode == nil {
 				mode := 0644
-				if info.Mode()&0111 != 0 {
+				if info, err := entry.Info(); err != nil {
+					r.AddOnError(yamlPath, err)
+					return nil
+				} else if info.Mode().Perm()&0111 != 0 {
 					mode = 0755
 				}
 				file.Mode = &mode
 				ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "mode"))
 			}
-		} else if info.Mode()&os.ModeType == os.ModeSymlink {
+			return nil
+
+		case typ&fs.ModeType == fs.ModeSymlink:
 			i, link := t.GetLink(destPath)
 			if link != nil {
 				if link.Target != "" {
@@ -347,17 +352,18 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "links"))
 				}
 			}
-			link.Target, err = os.Readlink(srcPath)
+			link.Target, err = fsutil.ReadLink(options.FS, srcPath)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
 			ts.AddTranslation(yamlPath, path.New("json", "storage", "links", i, "target"))
-		} else {
+			return nil
+
+		default:
 			r.AddOnError(yamlPath, common.ErrFileType)
 			return nil
 		}
-		return nil
 	})
 	r.AddOnError(yamlPath, err)
 }

--- a/base/v0_4_exp/translate_test.go
+++ b/base/v0_4_exp/translate_test.go
@@ -25,6 +25,7 @@ import (
 
 	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/internal/fsutil"
 	"github.com/coreos/fcct/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -209,7 +210,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// inline file contents
@@ -266,7 +267,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// filesDir not specified
@@ -302,7 +303,7 @@ func TestTranslateFile(t *testing.T) {
 			[]translate.Translation{},
 			"error at $.contents.local: " + common.ErrFilesDirEscape.Error() + "\n",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// attempted inclusion of nonexistent file
@@ -321,7 +322,7 @@ func TestTranslateFile(t *testing.T) {
 			[]translate.Translation{},
 			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": no such file or directory\n",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// inline and local automatic file encoding
@@ -424,7 +425,7 @@ func TestTranslateFile(t *testing.T) {
 			},
 			"",
 			common.TranslateOptions{
-				FilesDir: filesDir,
+				FS: fsutil.DirFS(filesDir),
 			},
 		},
 		// Test disable automatic gzip compression
@@ -1460,7 +1461,7 @@ func TestTranslateTree(t *testing.T) {
 			},
 		}
 		options := common.TranslateOptions{
-			FilesDir: filesDir,
+			FS: fsutil.DirFS(filesDir),
 		}
 		if test.options != nil {
 			options = *test.options

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -14,10 +14,16 @@
 
 package common
 
+import "io/fs"
+
 type TranslateOptions struct {
-	FilesDir                  string // allow embedding local files relative to this directory
-	NoResourceAutoCompression bool   // skip automatic compression of inline/local resources
-	DebugPrintTranslations    bool   // report translations to stderr
+	// FS allows embedding local files.
+	FS fs.FS
+	// NoResourceAutoCompression disables automatic compression
+	// of inline/local resources.
+	NoResourceAutoCompression bool
+	// DebugPrintTranslations reports translations to stderr.
+	DebugPrintTranslations    bool
 }
 
 type TranslateBytesOptions struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/fcct
 
-go 1.12
+go 1.16
 
 require (
 	github.com/clarketm/json v1.14.1

--- a/internal/fsutil/fs.go
+++ b/internal/fsutil/fs.go
@@ -1,0 +1,112 @@
+package fsutil
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"reflect"
+)
+
+// ErrNotImplemented is the sentinel error returned when an optional
+// feature is not implemented.
+var ErrNotImplemented = errors.New("not implemented")
+
+// An FS provides access to a hierarchical file system.
+type FS interface {
+	fs.FS
+	fs.StatFS
+	ReadLinkFS
+}
+
+// ReadLinkFS is the interface implemented by a file system
+// that provides an implementation of ReadLink.
+type ReadLinkFS interface {
+	fs.FS
+
+	// ReadLink returns the destination of the named symbolic link.
+	// If there is an error, it will be of type *fs.PathError.
+	ReadLink(name string) (string, error)
+}
+
+// DirFS returns a file system for the tree of files rooted at the directory dir.
+//
+// Note that DirFS("/prefix") only guarantees that the Open calls it makes to the
+// operating system will begin with "/prefix": DirFS("/prefix").Open("file") is the
+// same as os.Open("/prefix/file"). So if /prefix/file is a symbolic link pointing outside
+// the /prefix tree, then using DirFS does not stop the access any more than using
+// os.Open does. DirFS is therefore not a general substitute for a chroot-style
+// security mechanism when the directory tree contains arbitrary content.
+func DirFS(dir string) FS {
+	return dirFS(path.Clean(dir))
+}
+
+type dirFS string
+
+func (dir dirFS) Open(name string) (fs.File, error) {
+	if name = path.Clean(name); !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	f, err := os.Open(string(dir) + "/" + name)
+	if err != nil {
+		return nil, err // nil fs.File
+	}
+	return f, nil
+}
+
+func (dir dirFS) ReadLink(name string) (string, error) {
+	if name = path.Clean(name); !fs.ValidPath(name) {
+		return "", &fs.PathError{Op: "readlink", Path: name, Err: fs.ErrInvalid}
+	}
+	return os.Readlink(string(dir) + "/" + name)
+}
+
+func (dir dirFS) Stat(name string) (fs.FileInfo, error) {
+	if name = path.Clean(name); !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+	return os.Stat(string(dir) + "/" + name)
+}
+
+// ReadLink returns the destination of the named symbolic link.
+// If there is an error, it will be of type *fs.PathError.
+//
+// If fsys implements ReadLinkFS, ReadLink calls fs.ReadLink.
+// If fsys is the type returned by os.DirFS, ReadLink calls os.Readlink.
+// Otherwise an error is returned.
+func ReadLink(fsys fs.FS, name string) (string, error) {
+	name = path.Clean(name)
+	if fsys, ok := fsys.(ReadLinkFS); ok {
+		return fsys.ReadLink(name)
+	}
+	if fsys, ok := toDirFS(fsys); ok {
+		return fsys.ReadLink(name)
+	}
+	return "", &fs.PathError{Op: "readlink", Path: name, Err: ErrNotImplemented}
+}
+
+// Stat returns a FileInfo describing the named file from the file system.
+//
+// If fsys implements StatFS, Stat calls fsys.Stat.
+// If fsys is the type returned by os.DirFS, ReadLink calls os.Stat.
+// Otherwise, Stat opens the file to stat it.
+func Stat(fsys fs.FS, name string) (fs.FileInfo, error) {
+	name = path.Clean(name)
+	if fsys, ok := fsys.(fs.StatFS); ok {
+		return fsys.Stat(name)
+	}
+	if fsys, ok := toDirFS(fsys); ok {
+		return fsys.Stat(name)
+	}
+	return fs.Stat(fsys, name)
+}
+
+var osDirFSType = reflect.TypeOf(os.DirFS(""))
+
+func toDirFS(fsys fs.FS) (FS, bool) {
+	if reflect.TypeOf(fsys) == osDirFSType {
+		dir := reflect.ValueOf(fsys).String()
+		return dirFS(dir), true
+	}
+	return nil, false
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/fcct/config"
 	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/internal/fsutil"
 	"github.com/coreos/fcct/internal/version"
 )
 
@@ -33,10 +34,11 @@ func fail(format string, args ...interface{}) {
 
 func main() {
 	var (
-		input       string
-		output      string
-		helpFlag    bool
-		versionFlag bool
+		input        string
+		output       string
+		helpFlag     bool
+		versionFlag  bool
+		filesDirFlag string
 	)
 	options := common.TranslateBytesOptions{}
 	pflag.BoolVarP(&helpFlag, "help", "h", false, "show usage and exit")
@@ -49,7 +51,7 @@ func main() {
 	pflag.Lookup("input").Deprecated = "specify filename directly on command line"
 	pflag.Lookup("input").Hidden = true
 	pflag.StringVarP(&output, "output", "o", "", "write to output file instead of stdout")
-	pflag.StringVarP(&options.FilesDir, "files-dir", "d", "", "allow embedding local files from this directory")
+	pflag.StringVarP(&filesDirFlag, "files-dir", "d", "", "allow embedding local files from this directory")
 
 	pflag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options] [input-file]\n", os.Args[0])
@@ -74,6 +76,10 @@ func main() {
 	if versionFlag {
 		fmt.Println(version.String)
 		os.Exit(0)
+	}
+
+	if filesDirFlag != "" {
+		options.FS = fsutil.DirFS(filesDirFlag)
 	}
 
 	var infile *os.File = os.Stdin


### PR DESCRIPTION
This is very premature as it requires go 1.16, which is currently in beta. I'm opening this PR to get an idea if it (or something similar) might be welcome in the future. I would prefer not to maintain a separate fork, but would understand if it's necessary.

I have a server that templates, fetches, merges, and flattens Ignition configs. It also serves them embedded in ISOs and is used to break the chicken-and-egg problem of static network configuration. Currently it only supports raw Ignition configs (which are gross), but I'm adding support for FCCs (which are nice).

I would like to use a custom fs.FS implementation to let FCCs reference templated files that are rendered at transpile time.