### PR TITLE
workflows: work around podman build breakage

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,5 +13,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+      - name: Work around Podman breakage
+        run: |
+          mkdir -vp ~/.config/containers
+          echo -e "[storage.options]\nmount_program=\"/usr/bin/fuse-overlayfs\"" > ~/.config/containers/storage.conf
       - name: Build container image
         run: podman build .


### PR DESCRIPTION
Rootless Podman is broken in GitHub Actions Ubuntu 20.04 20210419.1.

https://github.com/actions/virtual-environments/issues/3229