### PR TITLE
Revert "workflows: work around podman build breakage"

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,9 +13,5 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Work around Podman breakage
-        run: |
-          mkdir -vp ~/.config/containers
-          echo -e "[storage.options]\nmount_program=\"/usr/bin/fuse-overlayfs\"" > ~/.config/containers/storage.conf
       - name: Build container image
         run: podman build .


### PR DESCRIPTION
We can revert the workaround once https://github.com/actions/virtual-environments/issues/3229 is fixed (and thus CI is green for this PR).

This reverts https://github.com/coreos/butane/pull/235.