### PR TITLE
Dockerfile: build container using Fedora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:latest AS builder
+FROM registry.fedoraproject.org/fedora:34 AS builder
+RUN dnf install -y golang git
 RUN mkdir /butane
 COPY . /butane
 WORKDIR /butane


### PR DESCRIPTION
Avoid build failures due to Docker Hub rate limits.