### PR TITLE
openshift/4.9: forbid Ignition spec 3.3.0 fields rejected by MCC

### DIFF
--- a/base/v0_4/translate.go
+++ b/base/v0_4/translate.go
@@ -95,7 +95,7 @@ func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Conf
 	tm, r := translate.Prefixed(tr, "ignition", &c.Ignition, &ret.Ignition)
 	tm.AddTranslation(path.New("yaml", "version"), path.New("json", "ignition", "version"))
 	tm.AddTranslation(path.New("yaml", "ignition"), path.New("json", "ignition"))
-	translate.MergeP(tr, tm, &r, "kernel_arguments", &c.KernelArguments, &ret.KernelArguments)
+	translate.MergeP2(tr, tm, &r, "kernel_arguments", &c.KernelArguments, "kernelArguments", &ret.KernelArguments)
 	translate.MergeP(tr, tm, &r, "passwd", &c.Passwd, &ret.Passwd)
 	translate.MergeP(tr, tm, &r, "storage", &c.Storage, &ret.Storage)
 	translate.MergeP(tr, tm, &r, "systemd", &c.Systemd, &ret.Systemd)

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -1573,6 +1573,49 @@ func TestTranslateIgnition(t *testing.T) {
 	}
 }
 
+// TestTranslateKernelArguments tests translating the butane kernel_arguments.{should_exist,should_not_exist}.[i] entries to
+// ignition kernelArguments.{shouldExist,shouldNotExist}.[i] entries.
+//
+// KernelArguments do not use a custom translation function (it utilizes the MergeP2 functionality) so pass an entire config
+func TestTranslateKernelArguments(t *testing.T) {
+	tests := []struct {
+		in  Config
+		out types.Config
+	}{
+		{
+			Config{
+				KernelArguments: KernelArguments{
+					ShouldExist: []KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []KernelArgument{
+						"bar",
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.3.0",
+				},
+				KernelArguments: types.KernelArguments{
+					ShouldExist: []types.KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []types.KernelArgument{
+						"bar",
+					},
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+	}
+}
+
 // TestToIgn3_3 tests the config.ToIgn3_3 function ensuring it will generate a valid config even when empty. Not much else is
 // tested since it uses the Ignition translation code which has it's own set of tests.
 func TestToIgn3_3(t *testing.T) {

--- a/base/v0_5_exp/translate.go
+++ b/base/v0_5_exp/translate.go
@@ -95,7 +95,7 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 	tm, r := translate.Prefixed(tr, "ignition", &c.Ignition, &ret.Ignition)
 	tm.AddTranslation(path.New("yaml", "version"), path.New("json", "ignition", "version"))
 	tm.AddTranslation(path.New("yaml", "ignition"), path.New("json", "ignition"))
-	translate.MergeP(tr, tm, &r, "kernel_arguments", &c.KernelArguments, &ret.KernelArguments)
+	translate.MergeP2(tr, tm, &r, "kernel_arguments", &c.KernelArguments, "kernelArguments", &ret.KernelArguments)
 	translate.MergeP(tr, tm, &r, "passwd", &c.Passwd, &ret.Passwd)
 	translate.MergeP(tr, tm, &r, "storage", &c.Storage, &ret.Storage)
 	translate.MergeP(tr, tm, &r, "systemd", &c.Systemd, &ret.Systemd)

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -1573,6 +1573,49 @@ func TestTranslateIgnition(t *testing.T) {
 	}
 }
 
+// TestTranslateKernelArguments tests translating the butane kernel_arguments.{should_exist,should_not_exist}.[i] entries to
+// ignition kernelArguments.{shouldExist,shouldNotExist}.[i] entries.
+//
+// KernelArguments do not use a custom translation function (it utilizes the MergeP2 functionality) so pass an entire config
+func TestTranslateKernelArguments(t *testing.T) {
+	tests := []struct {
+		in  Config
+		out types.Config
+	}{
+		{
+			Config{
+				KernelArguments: KernelArguments{
+					ShouldExist: []KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []KernelArgument{
+						"bar",
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.4.0-experimental",
+				},
+				KernelArguments: types.KernelArguments{
+					ShouldExist: []types.KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []types.KernelArgument{
+						"bar",
+					},
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+	}
+}
+
 // TestToIgn3_4 tests the config.ToIgn3_4 function ensuring it will generate a valid config even when empty. Not much else is
 // tested since it uses the Ignition translation code which has it's own set of tests.
 func TestToIgn3_4(t *testing.T) {

--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -60,4 +60,5 @@ var (
 	ErrGroupSupport           = errors.New("groups are not supported in this spec version")
 	ErrUserFieldSupport       = errors.New("fields other than \"name\" and \"ssh_authorized_keys\" are not supported in this spec version")
 	ErrUserNameSupport        = errors.New("users other than \"core\" are not supported in this spec version")
+	ErrKernelArgumentSupport  = errors.New("this field cannot be used for kernel arguments in this spec version; use openshift.kernel_arguments instead")
 )

--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -53,6 +53,7 @@ var (
 	ErrRoleRequired           = errors.New("machineconfiguration.openshift.io/role label is required")
 	ErrInvalidKernelType      = errors.New("must be empty, \"default\", or \"realtime\"")
 	ErrBtrfsSupport           = errors.New("btrfs is not supported in this spec version")
+	ErrFilesystemNoneSupport  = errors.New("format \"none\" is not supported in this spec version")
 	ErrDirectorySupport       = errors.New("directories are not supported in this spec version")
 	ErrFileAppendSupport      = errors.New("appending to files is not supported in this spec version")
 	ErrFileCompressionSupport = errors.New("file compression is not supported in this spec version")

--- a/config/openshift/v4_9_exp/translate.go
+++ b/config/openshift/v4_9_exp/translate.go
@@ -229,6 +229,12 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 	// incorrect state to the node.
 
 	var r report.Report
+	for i, fs := range mc.Spec.Config.Storage.Filesystems {
+		if fs.Format != nil && *fs.Format == "none" {
+			// UNPARSABLE
+			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrFilesystemNoneSupport)
+		}
+	}
 	for i := range mc.Spec.Config.Storage.Directories {
 		// IMMUTABLE
 		r.AddOnError(path.New("json", "spec", "config", "storage", "directories", i), common.ErrDirectorySupport)

--- a/config/openshift/v4_9_exp/translate.go
+++ b/config/openshift/v4_9_exp/translate.go
@@ -203,8 +203,15 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
 	// Error classes for the purposes of this function:
 	//
+	// UNPARSABLE - Cannot be rendered into a config by the MCC.  If
+	// present in MC, MCC will mark the pool degraded.  We reject these.
+	//
 	// FORBIDDEN - Not supported by the MCD.  If present in MC, MCD will
 	// mark the node degraded.  We reject these.
+	//
+	// REDUNDANT - Feature is also provided by a MachineConfig-specific
+	// field with different semantics.  To reduce confusion, disable
+	// this implementation.
 	//
 	// IMMUTABLE - Permitted in MC, passed through to Ignition, but not
 	// supported by the MCD.  MCD will mark the node degraded if the
@@ -271,6 +278,14 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			// TRIPWIRE
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
+	}
+	for i := range mc.Spec.Config.KernelArguments.ShouldExist {
+		// UNPARSABLE, REDUNDANT
+		r.AddOnError(path.New("json", "spec", "config", "kernelArguments", "shouldExist", i), common.ErrKernelArgumentSupport)
+	}
+	for i := range mc.Spec.Config.KernelArguments.ShouldNotExist {
+		// UNPARSABLE, REDUNDANT
+		r.AddOnError(path.New("json", "spec", "config", "kernelArguments", "shouldNotExist", i), common.ErrKernelArgumentSupport)
 	}
 	return cutil.TranslateReportPaths(r, ts)
 }

--- a/config/openshift/v4_9_exp/translate_test.go
+++ b/config/openshift/v4_9_exp/translate_test.go
@@ -433,6 +433,10 @@ func TestValidateSupport(t *testing.T) {
 									Device: "/dev/vda4",
 									Format: util.StrToPtr("btrfs"),
 								},
+								{
+									Device: "/dev/vda5",
+									Format: util.StrToPtr("none"),
+								},
 							},
 							Directories: []base.Directory{
 								{
@@ -489,6 +493,7 @@ func TestValidateSupport(t *testing.T) {
 			},
 			[]entry{
 				{report.Error, common.ErrBtrfsSupport, path.New("yaml", "storage", "filesystems", 0, "format")},
+				{report.Error, common.ErrFilesystemNoneSupport, path.New("yaml", "storage", "filesystems", 1, "format")},
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
 				{report.Error, common.ErrFileCompressionSupport, path.New("yaml", "storage", "files", 1, "contents", "compression")},

--- a/config/openshift/v4_9_exp/translate_test.go
+++ b/config/openshift/v4_9_exp/translate_test.go
@@ -476,6 +476,14 @@ func TestValidateSupport(t *testing.T) {
 								},
 							},
 						},
+						KernelArguments: base.KernelArguments{
+							ShouldExist: []base.KernelArgument{
+								"foo",
+							},
+							ShouldNotExist: []base.KernelArgument{
+								"bar",
+							},
+						},
 					},
 				},
 			},
@@ -499,6 +507,8 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "system")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "uid")},
 				{report.Error, common.ErrUserNameSupport, path.New("yaml", "passwd", "users", 1)},
+				{report.Error, common.ErrKernelArgumentSupport, path.New("yaml", "kernel_arguments", "should_exist", 0)},
+				{report.Error, common.ErrKernelArgumentSupport, path.New("yaml", "kernel_arguments", "should_not_exist", 0)},
 			},
 		},
 	}

--- a/docs/config-fcos-v1_4-exp.md
+++ b/docs/config-fcos-v1_4-exp.md
@@ -73,7 +73,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_options_** (list of strings): any additional options to be passed to mdadm.
   * **_filesystems_** (list of objects): the list of filesystems to be configured. `device` and `format` need to be specified. Every filesystem must have a unique `device`.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
-    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, or swap).
+    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, swap, or none).
     * **_path_** (string): the mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
     * **_wipe_filesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information. Defaults to false.
     * **_label_** (string): the label of the filesystem.

--- a/docs/config-openshift-v4_9-exp.md
+++ b/docs/config-openshift-v4_9-exp.md
@@ -147,9 +147,6 @@ The OpenShift configuration is a YAML document conforming to the following speci
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
     * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
-* **_kernel_arguments_** (object): describes the desired kernel arguments.
-  * **_should_exist_** (list of strings): the list of kernel arguments that should exist.
-  * **_should_not_exist_** (list of strings): the list of kernel arguments that should not exist.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.


### PR DESCRIPTION
The MCC in OCP 4.9 is unable to parse Ignition 3.3.0 configs that are not also valid 3.2.0 configs.  Reject affected fields.

In addition, we don't want to expose `KernelArguments` in two different places that have different semantics. Document that we want to reject the Ignition `KernelArguments` fields to encourage the use of the MCO's related field, as it will also affect subsequent boots.

Closes #237.