### PR TITLE
go.mod: bump Go to 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/butane
 
-go 1.12
+go 1.13
 
 require (
 	github.com/clarketm/json v1.14.1


### PR DESCRIPTION
Ignition requires it, and we don't test anything older in CI.

xref https://github.com/coreos/ignition/pull/1225