### PR TITLE
templates: vendor new Butane releases into mantle

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -49,3 +49,6 @@ Quay release:
  - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm
  - [ ] Visit the [Quay tags page](https://quay.io/repository/coreos/fcct?tab=tags) for the legacy FCCT repo and wait for a versioned tag to appear
  - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm
+
+Housekeeping:
+ - [ ] Vendor the new Butane version in [mantle](https://github.com/coreos/coreos-assembler/tree/main/mantle)


### PR DESCRIPTION
Requires https://github.com/coreos/coreos-assembler/pull/2246.