### PR TITLE
base/v0_4: fix kernel argument merging

### DIFF
--- a/base/v0_4/translate.go
+++ b/base/v0_4/translate.go
@@ -95,7 +95,7 @@ func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Conf
 	tm, r := translate.Prefixed(tr, "ignition", &c.Ignition, &ret.Ignition)
 	tm.AddTranslation(path.New("yaml", "version"), path.New("json", "ignition", "version"))
 	tm.AddTranslation(path.New("yaml", "ignition"), path.New("json", "ignition"))
-	translate.MergeP(tr, tm, &r, "kernel_arguments", &c.KernelArguments, &ret.KernelArguments)
+	translate.MergeP2(tr, tm, &r, "kernel_arguments", &c.KernelArguments, "kernelArguments", &ret.KernelArguments)
 	translate.MergeP(tr, tm, &r, "passwd", &c.Passwd, &ret.Passwd)
 	translate.MergeP(tr, tm, &r, "storage", &c.Storage, &ret.Storage)
 	translate.MergeP(tr, tm, &r, "systemd", &c.Systemd, &ret.Systemd)

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -1573,6 +1573,49 @@ func TestTranslateIgnition(t *testing.T) {
 	}
 }
 
+// TestTranslateKernelArguments tests translating the butane kernel_arguments.{should_exist,should_not_exist}.[i] entries to
+// ignition kernelArguments.{shouldExist,shouldNotExist}.[i] entries.
+//
+// KernelArguments do not use a custom translation function (it utilizes the MergeP2 functionality) so pass an entire config
+func TestTranslateKernelArguments(t *testing.T) {
+	tests := []struct {
+		in  Config
+		out types.Config
+	}{
+		{
+			Config{
+				KernelArguments: KernelArguments{
+					ShouldExist: []KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []KernelArgument{
+						"bar",
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.3.0",
+				},
+				KernelArguments: types.KernelArguments{
+					ShouldExist: []types.KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []types.KernelArgument{
+						"bar",
+					},
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+	}
+}
+
 // TestToIgn3_3 tests the config.ToIgn3_3 function ensuring it will generate a valid config even when empty. Not much else is
 // tested since it uses the Ignition translation code which has it's own set of tests.
 func TestToIgn3_3(t *testing.T) {

--- a/base/v0_5_exp/translate.go
+++ b/base/v0_5_exp/translate.go
@@ -95,7 +95,7 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 	tm, r := translate.Prefixed(tr, "ignition", &c.Ignition, &ret.Ignition)
 	tm.AddTranslation(path.New("yaml", "version"), path.New("json", "ignition", "version"))
 	tm.AddTranslation(path.New("yaml", "ignition"), path.New("json", "ignition"))
-	translate.MergeP(tr, tm, &r, "kernel_arguments", &c.KernelArguments, &ret.KernelArguments)
+	translate.MergeP2(tr, tm, &r, "kernel_arguments", &c.KernelArguments, "kernelArguments", &ret.KernelArguments)
 	translate.MergeP(tr, tm, &r, "passwd", &c.Passwd, &ret.Passwd)
 	translate.MergeP(tr, tm, &r, "storage", &c.Storage, &ret.Storage)
 	translate.MergeP(tr, tm, &r, "systemd", &c.Systemd, &ret.Systemd)

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -1573,6 +1573,49 @@ func TestTranslateIgnition(t *testing.T) {
 	}
 }
 
+// TestTranslateKernelArguments tests translating the butane kernel_arguments.{should_exist,should_not_exist}.[i] entries to
+// ignition kernelArguments.{shouldExist,shouldNotExist}.[i] entries.
+//
+// KernelArguments do not use a custom translation function (it utilizes the MergeP2 functionality) so pass an entire config
+func TestTranslateKernelArguments(t *testing.T) {
+	tests := []struct {
+		in  Config
+		out types.Config
+	}{
+		{
+			Config{
+				KernelArguments: KernelArguments{
+					ShouldExist: []KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []KernelArgument{
+						"bar",
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.4.0-experimental",
+				},
+				KernelArguments: types.KernelArguments{
+					ShouldExist: []types.KernelArgument{
+						"foo",
+					},
+					ShouldNotExist: []types.KernelArgument{
+						"bar",
+					},
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+	}
+}
+
 // TestToIgn3_4 tests the config.ToIgn3_4 function ensuring it will generate a valid config even when empty. Not much else is
 // tested since it uses the Ignition translation code which has it's own set of tests.
 func TestToIgn3_4(t *testing.T) {


### PR DESCRIPTION
MergeP doesn't know how to do/undo camelcasing so we're not correctly building the TranslationSet for kernel arguments. Switch to MergeP2 and add a test for it.

Split out from https://github.com/coreos/butane/pull/250.