### PR TITLE
openshift/v4_9: roll back to Ignition spec 3.2.0

### DIFF
--- a/config/openshift/v4_9/result/schema.go
+++ b/config/openshift/v4_9/result/schema.go
@@ -15,7 +15,7 @@
 package result
 
 import (
-	"github.com/coreos/ignition/v2/config/v3_3/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 )
 
 const (

--- a/config/openshift/v4_9/schema.go
+++ b/config/openshift/v4_9/schema.go
@@ -15,7 +15,7 @@
 package v4_9
 
 import (
-	fcos "github.com/coreos/butane/config/fcos/v1_4"
+	fcos "github.com/coreos/butane/config/fcos/v1_3"
 )
 
 const ROLE_LABEL_KEY = "machineconfiguration.openshift.io/role"

--- a/config/openshift/v4_9/translate.go
+++ b/config/openshift/v4_9/translate.go
@@ -24,7 +24,7 @@ import (
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/ignition/v2/config/v3_3/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
@@ -45,7 +45,7 @@ func (c Config) ToMachineConfig4_9Unvalidated(options common.TranslateOptions) (
 	// https://bugzilla.redhat.com/show_bug.cgi?id=1970218
 	options.NoResourceAutoCompression = true
 
-	cfg, ts, r := c.Config.ToIgn3_3Unvalidated(options)
+	cfg, ts, r := c.Config.ToIgn3_2Unvalidated(options)
 	if r.IsFatal() {
 		return result.MachineConfig{}, ts, r
 	}
@@ -105,11 +105,11 @@ func (c Config) ToMachineConfig4_9(options common.TranslateOptions) (result.Mach
 	return cfg.(result.MachineConfig), r, err
 }
 
-// ToIgn3_3Unvalidated translates the config to an Ignition config.  It also
+// ToIgn3_2Unvalidated translates the config to an Ignition config.  It also
 // returns the set of translations it did so paths in the resultant config
 // can be tracked back to their source in the source config.  No config
 // validation is performed on input or output.
-func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
 	mc, ts, r := c.ToMachineConfig4_9Unvalidated(options)
 	cfg := mc.Spec.Config
 
@@ -124,21 +124,21 @@ func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Conf
 	return cfg, ts, r
 }
 
-// ToIgn3_3 translates the config to an Ignition config.  It returns a
+// ToIgn3_2 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If
 // the report has fatal errors or it encounters other problems translating,
 // an error is returned.
-func (c Config) ToIgn3_3(options common.TranslateOptions) (types.Config, report.Report, error) {
-	cfg, r, err := cutil.Translate(c, "ToIgn3_3Unvalidated", options)
+func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_2Unvalidated", options)
 	return cfg.(types.Config), r, err
 }
 
-// ToConfigBytes translates from a v4.9 Butane config to a v4.9 MachineConfig or a v3.3.0 Ignition config. It returns a report of any errors or
+// ToConfigBytes translates from a v4.9 Butane config to a v4.9 MachineConfig or a v3.2.0 Ignition config. It returns a report of any errors or
 // warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
 // translating, an error is returned.
 func ToConfigBytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
 	if options.Raw {
-		return cutil.TranslateBytes(input, &Config{}, "ToIgn3_3", options)
+		return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
 	} else {
 		return cutil.TranslateBytesYAML(input, &Config{}, "ToMachineConfig4_9", options)
 	}
@@ -203,15 +203,8 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
 	// Error classes for the purposes of this function:
 	//
-	// UNPARSABLE - Cannot be rendered into a config by the MCC.  If
-	// present in MC, MCC will mark the pool degraded.  We reject these.
-	//
 	// FORBIDDEN - Not supported by the MCD.  If present in MC, MCD will
 	// mark the node degraded.  We reject these.
-	//
-	// REDUNDANT - Feature is also provided by a MachineConfig-specific
-	// field with different semantics.  To reduce confusion, disable
-	// this implementation.
 	//
 	// IMMUTABLE - Permitted in MC, passed through to Ignition, but not
 	// supported by the MCD.  MCD will mark the node degraded if the
@@ -229,12 +222,6 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 	// incorrect state to the node.
 
 	var r report.Report
-	for i, fs := range mc.Spec.Config.Storage.Filesystems {
-		if fs.Format != nil && *fs.Format == "none" {
-			// UNPARSABLE
-			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrFilesystemNoneSupport)
-		}
-	}
 	for i := range mc.Spec.Config.Storage.Directories {
 		// IMMUTABLE
 		r.AddOnError(path.New("json", "spec", "config", "storage", "directories", i), common.ErrDirectorySupport)
@@ -284,14 +271,6 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			// TRIPWIRE
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
-	}
-	for i := range mc.Spec.Config.KernelArguments.ShouldExist {
-		// UNPARSABLE, REDUNDANT
-		r.AddOnError(path.New("json", "spec", "config", "kernelArguments", "shouldExist", i), common.ErrKernelArgumentSupport)
-	}
-	for i := range mc.Spec.Config.KernelArguments.ShouldNotExist {
-		// UNPARSABLE, REDUNDANT
-		r.AddOnError(path.New("json", "spec", "config", "kernelArguments", "shouldNotExist", i), common.ErrKernelArgumentSupport)
 	}
 	return cutil.TranslateReportPaths(r, ts)
 }

--- a/config/openshift/v4_9/translate_test.go
+++ b/config/openshift/v4_9/translate_test.go
@@ -18,14 +18,14 @@ import (
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
-	base "github.com/coreos/butane/base/v0_4"
+	base "github.com/coreos/butane/base/v0_3"
 	"github.com/coreos/butane/config/common"
-	fcos "github.com/coreos/butane/config/fcos/v1_4"
+	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_9/result"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/ignition/v2/config/v3_3/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +50,7 @@ func TestElidedFieldWarning(t *testing.T) {
 	expected.AddOnWarn(path.New("yaml", "openshift", "fips"), common.ErrFieldElided)
 	expected.AddOnWarn(path.New("yaml", "openshift", "kernel_type"), common.ErrFieldElided)
 
-	_, _, r := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+	_, _, r := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
 	assert.Equal(t, expected, r, "report mismatch")
 }
 
@@ -83,7 +83,7 @@ func TestTranslateConfig(t *testing.T) {
 				Spec: result.Spec{
 					Config: types.Config{
 						Ignition: types.Ignition{
-							Version: "3.3.0",
+							Version: "3.2.0",
 						},
 					},
 				},
@@ -133,7 +133,7 @@ func TestTranslateConfig(t *testing.T) {
 				Spec: result.Spec{
 					Config: types.Config{
 						Ignition: types.Ignition{
-							Version: "3.3.0",
+							Version: "3.2.0",
 						},
 						Storage: types.Storage{
 							Files: []types.File{
@@ -228,7 +228,7 @@ func TestTranslateConfig(t *testing.T) {
 				Spec: result.Spec{
 					Config: types.Config{
 						Ignition: types.Ignition{
-							Version: "3.3.0",
+							Version: "3.2.0",
 						},
 						Storage: types.Storage{
 							Filesystems: []types.Filesystem{
@@ -246,7 +246,7 @@ func TestTranslateConfig(t *testing.T) {
 									Label:      util.StrToPtr("luks-root"),
 									WipeVolume: util.BoolToPtr(true),
 									Options:    []types.LuksOption{fipsCipherOption, fipsCipherArgument},
-									Clevis: types.Clevis{
+									Clevis: &types.Clevis{
 										Tpm2: util.BoolToPtr(true),
 									},
 								},
@@ -433,10 +433,6 @@ func TestValidateSupport(t *testing.T) {
 									Device: "/dev/vda4",
 									Format: util.StrToPtr("btrfs"),
 								},
-								{
-									Device: "/dev/vda5",
-									Format: util.StrToPtr("none"),
-								},
 							},
 							Directories: []base.Directory{
 								{
@@ -446,7 +442,7 @@ func TestValidateSupport(t *testing.T) {
 							Links: []base.Link{
 								{
 									Path:   "/l",
-									Target: util.StrToPtr("/t"),
+									Target: "/t",
 								},
 							},
 						},
@@ -480,20 +476,11 @@ func TestValidateSupport(t *testing.T) {
 								},
 							},
 						},
-						KernelArguments: base.KernelArguments{
-							ShouldExist: []base.KernelArgument{
-								"foo",
-							},
-							ShouldNotExist: []base.KernelArgument{
-								"bar",
-							},
-						},
 					},
 				},
 			},
 			[]entry{
 				{report.Error, common.ErrBtrfsSupport, path.New("yaml", "storage", "filesystems", 0, "format")},
-				{report.Error, common.ErrFilesystemNoneSupport, path.New("yaml", "storage", "filesystems", 1, "format")},
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
 				{report.Error, common.ErrFileCompressionSupport, path.New("yaml", "storage", "files", 1, "contents", "compression")},
@@ -512,8 +499,6 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "system")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "uid")},
 				{report.Error, common.ErrUserNameSupport, path.New("yaml", "passwd", "users", 1)},
-				{report.Error, common.ErrKernelArgumentSupport, path.New("yaml", "kernel_arguments", "should_exist", 0)},
-				{report.Error, common.ErrKernelArgumentSupport, path.New("yaml", "kernel_arguments", "should_not_exist", 0)},
 			},
 		},
 	}

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -10,7 +10,7 @@ nav_order: 97
 The OpenShift configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `openshift` for this specification.
-* **version** (string): the semantic version of the spec for this document. This document is for version `4.9.0` and generates Ignition configs with version `3.3.0`.
+* **version** (string): the semantic version of the spec for this document. This document is for version `4.9.0` and generates Ignition configs with version `3.2.0`.
 * **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
   * **name** (string): a unique [name][k8s-names] for this MachineConfig resource.
   * **labels** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource. `machineconfiguration.openshift.io/role` is required.

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -54,6 +54,6 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `fcos`         | 1.4.0               | 3.3.0              |
 | `fcos`         | 1.5.0-experimental  | 3.4.0-experimental |
 | `openshift`    | 4.8.0               | 3.2.0              |
-| `openshift`    | 4.9.0               | 3.3.0              |
+| `openshift`    | 4.9.0               | 3.2.0              |
 | `openshift`    | 4.10.0-experimental | 3.4.0-experimental |
 | `rhcos`        | 0.1.0               | 3.2.0              |


### PR DESCRIPTION
The MCO PR (https://github.com/openshift/machine-config-operator/pull/2675) to support spec 3.3.0 in OpenShift 4.9 didn't land in time.  Revert `openshift`/`4.9.0` to spec 3.2.0.

This is a semver violation for the `openshift`/`4.9.0` spec, which is unfortunate.  However, it doesn't break existing configs, because we already reject configs that use any new features from 3.3.0.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1989454