### PR TITLE
main: Write output ignition files with mode 0600

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -102,7 +102,9 @@ func main() {
 
 	if output != "" {
 		var err error
-		outfile, err = os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		// Because the config is commonly expected to have secret values, use mode 0600.
+		// xref https://github.com/coreos/fedora-coreos-docs/issues/306
+		outfile, err = os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			fail("failed to open %s: %v\n", output, err)
 		}

--- a/test
+++ b/test
@@ -29,6 +29,24 @@ trap 'rm -r tmpdocs' EXIT
 mkdir -p tmpdocs/files-dir/tree
 touch tmpdocs/files-dir/{config.ign,ca.pem,file,file-epilogue,local-file3}
 
+tmpd=$(mktemp -d)
+${BIN_PATH}/${NAME} --strict --output ${tmpd}/foo.ign << 'EOF'
+variant: fcos
+version: 1.1.0
+storage:
+  files:
+    - path: /etc/somesecret
+      mode: 0600
+      contents:
+        source: https://example.com/etc/somesecret
+EOF
+m=$(stat -c '%a' ${tmpd}/foo.ign)
+rm -rf "${tmpd}"
+if test "${m}" != 600; then
+	echo "Unexpected ignition mode: ${m}" 1>&2
+	exit 1
+fi
+
 for doc in docs/*md
 do
 	echo "Checking $doc"


### PR DESCRIPTION
Because the config is commonly expected to have secret values, use mode 0600.
xref https://github.com/coreos/fedora-coreos-docs/issues/306