### PR TITLE
config/fcos/*: add reserved partitions on aarch64/ppc64le

### DIFF
--- a/config/fcos/v1_3/translate.go
+++ b/config/fcos/v1_3/translate.go
@@ -29,18 +29,14 @@ import (
 )
 
 const (
-	biosTypeGuid = "21686148-6449-6E6F-744E-656564454649"
-	prepTypeGuid = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
-	espTypeGuid  = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+	reservedTypeGuid = "8DA63339-0007-60C0-C436-083AC8230908"
+	biosTypeGuid     = "21686148-6449-6E6F-744E-656564454649"
+	prepTypeGuid     = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
+	espTypeGuid      = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
 
 	// The partition layout implemented in this file replicates
 	// the layout of the OS image defined in:
 	// https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh
-	//
-	// Exception: we don't try to skip unused partition numbers,
-	// because specifying a partition number would prevent child
-	// configs from overriding partition fields using the partition
-	// label as the lookup key.
 	//
 	// It's not critical that we match that layout exactly; the hard
 	// constraints are:
@@ -51,10 +47,11 @@ const (
 	//
 	// Do not change these constants!  New partition layouts must be
 	// encoded into new layout templates.
-	biosV1SizeMiB = 1
-	prepV1SizeMiB = 4
-	espV1SizeMiB  = 127
-	bootV1SizeMiB = 384
+	reservedV1SizeMiB = 1
+	biosV1SizeMiB     = 1
+	prepV1SizeMiB     = 4
+	espV1SizeMiB      = 127
+	bootV1SizeMiB     = 384
 )
 
 // ToIgn3_2Unvalidated translates the config to an Ignition config.  It also
@@ -131,12 +128,17 @@ func (c Config) processBootDevice(config *types.Config, ts *translate.Translatio
 					SizeMiB:  util.IntToPtr(biosV1SizeMiB),
 					TypeGUID: util.StrToPtr(biosTypeGuid),
 				})
-			}
-			if wantPRePPart {
+			} else if wantPRePPart {
 				disk.Partitions = append(disk.Partitions, types.Partition{
 					Label:    util.StrToPtr(fmt.Sprintf("prep-%d", labelIndex)),
 					SizeMiB:  util.IntToPtr(prepV1SizeMiB),
 					TypeGUID: util.StrToPtr(prepTypeGuid),
+				})
+			} else {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("reserved-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+					TypeGUID: util.StrToPtr(reservedTypeGuid),
 				})
 			}
 			if wantEFIPart {
@@ -144,6 +146,12 @@ func (c Config) processBootDevice(config *types.Config, ts *translate.Translatio
 					Label:    util.StrToPtr(fmt.Sprintf("esp-%d", labelIndex)),
 					SizeMiB:  util.IntToPtr(espV1SizeMiB),
 					TypeGUID: util.StrToPtr(espTypeGuid),
+				})
+			} else {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("reserved-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+					TypeGUID: util.StrToPtr(reservedTypeGuid),
 				})
 			}
 			disk.Partitions = append(disk.Partitions, types.Partition{

--- a/config/fcos/v1_3/translate_test.go
+++ b/config/fcos/v1_3/translate_test.go
@@ -656,6 +656,11 @@ func TestTranslateBootDevice(t *testing.T) {
 							Device: "/dev/vda",
 							Partitions: []types.Partition{
 								{
+									Label:    util.StrToPtr("reserved-1"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
+								{
 									Label:    util.StrToPtr("esp-1"),
 									SizeMiB:  util.IntToPtr(espV1SizeMiB),
 									TypeGUID: util.StrToPtr(espTypeGuid),
@@ -673,6 +678,11 @@ func TestTranslateBootDevice(t *testing.T) {
 						{
 							Device: "/dev/vdb",
 							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("reserved-2"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
 								{
 									Label:    util.StrToPtr("esp-2"),
 									SizeMiB:  util.IntToPtr(espV1SizeMiB),
@@ -758,9 +768,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0)},
@@ -776,9 +790,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1)},
@@ -863,6 +881,11 @@ func TestTranslateBootDevice(t *testing.T) {
 									TypeGUID: util.StrToPtr(prepTypeGuid),
 								},
 								{
+									Label:    util.StrToPtr("reserved-1"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
+								{
 									Label:   util.StrToPtr("boot-1"),
 									SizeMiB: util.IntToPtr(bootV1SizeMiB),
 								},
@@ -879,6 +902,11 @@ func TestTranslateBootDevice(t *testing.T) {
 									Label:    util.StrToPtr("prep-2"),
 									SizeMiB:  util.IntToPtr(prepV1SizeMiB),
 									TypeGUID: util.StrToPtr(prepTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("reserved-2"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
 								},
 								{
 									Label:   util.StrToPtr("boot-2"),
@@ -950,9 +978,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0)},
@@ -963,9 +995,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1)},
@@ -1266,6 +1302,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	// The partition sizes of existing layouts must never change, but
 	// we use the constants in tests for clarity.  Ensure no one has
 	// changed them.
+	assert.Equal(t, reservedV1SizeMiB, 1)
 	assert.Equal(t, biosV1SizeMiB, 1)
 	assert.Equal(t, prepV1SizeMiB, 4)
 	assert.Equal(t, espV1SizeMiB, 127)

--- a/config/fcos/v1_4/translate.go
+++ b/config/fcos/v1_4/translate.go
@@ -29,18 +29,14 @@ import (
 )
 
 const (
-	biosTypeGuid = "21686148-6449-6E6F-744E-656564454649"
-	prepTypeGuid = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
-	espTypeGuid  = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+	reservedTypeGuid = "8DA63339-0007-60C0-C436-083AC8230908"
+	biosTypeGuid     = "21686148-6449-6E6F-744E-656564454649"
+	prepTypeGuid     = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
+	espTypeGuid      = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
 
 	// The partition layout implemented in this file replicates
 	// the layout of the OS image defined in:
 	// https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh
-	//
-	// Exception: we don't try to skip unused partition numbers,
-	// because specifying a partition number would prevent child
-	// configs from overriding partition fields using the partition
-	// label as the lookup key.
 	//
 	// It's not critical that we match that layout exactly; the hard
 	// constraints are:
@@ -51,10 +47,11 @@ const (
 	//
 	// Do not change these constants!  New partition layouts must be
 	// encoded into new layout templates.
-	biosV1SizeMiB = 1
-	prepV1SizeMiB = 4
-	espV1SizeMiB  = 127
-	bootV1SizeMiB = 384
+	reservedV1SizeMiB = 1
+	biosV1SizeMiB     = 1
+	prepV1SizeMiB     = 4
+	espV1SizeMiB      = 127
+	bootV1SizeMiB     = 384
 )
 
 // ToIgn3_3Unvalidated translates the config to an Ignition config.  It also
@@ -131,12 +128,17 @@ func (c Config) processBootDevice(config *types.Config, ts *translate.Translatio
 					SizeMiB:  util.IntToPtr(biosV1SizeMiB),
 					TypeGUID: util.StrToPtr(biosTypeGuid),
 				})
-			}
-			if wantPRePPart {
+			} else if wantPRePPart {
 				disk.Partitions = append(disk.Partitions, types.Partition{
 					Label:    util.StrToPtr(fmt.Sprintf("prep-%d", labelIndex)),
 					SizeMiB:  util.IntToPtr(prepV1SizeMiB),
 					TypeGUID: util.StrToPtr(prepTypeGuid),
+				})
+			} else {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("reserved-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+					TypeGUID: util.StrToPtr(reservedTypeGuid),
 				})
 			}
 			if wantEFIPart {
@@ -144,6 +146,12 @@ func (c Config) processBootDevice(config *types.Config, ts *translate.Translatio
 					Label:    util.StrToPtr(fmt.Sprintf("esp-%d", labelIndex)),
 					SizeMiB:  util.IntToPtr(espV1SizeMiB),
 					TypeGUID: util.StrToPtr(espTypeGuid),
+				})
+			} else {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("reserved-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+					TypeGUID: util.StrToPtr(reservedTypeGuid),
 				})
 			}
 			disk.Partitions = append(disk.Partitions, types.Partition{

--- a/config/fcos/v1_4/translate_test.go
+++ b/config/fcos/v1_4/translate_test.go
@@ -656,6 +656,11 @@ func TestTranslateBootDevice(t *testing.T) {
 							Device: "/dev/vda",
 							Partitions: []types.Partition{
 								{
+									Label:    util.StrToPtr("reserved-1"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
+								{
 									Label:    util.StrToPtr("esp-1"),
 									SizeMiB:  util.IntToPtr(espV1SizeMiB),
 									TypeGUID: util.StrToPtr(espTypeGuid),
@@ -673,6 +678,11 @@ func TestTranslateBootDevice(t *testing.T) {
 						{
 							Device: "/dev/vdb",
 							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("reserved-2"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
 								{
 									Label:    util.StrToPtr("esp-2"),
 									SizeMiB:  util.IntToPtr(espV1SizeMiB),
@@ -758,9 +768,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0)},
@@ -776,9 +790,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1)},
@@ -863,6 +881,11 @@ func TestTranslateBootDevice(t *testing.T) {
 									TypeGUID: util.StrToPtr(prepTypeGuid),
 								},
 								{
+									Label:    util.StrToPtr("reserved-1"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
+								{
 									Label:   util.StrToPtr("boot-1"),
 									SizeMiB: util.IntToPtr(bootV1SizeMiB),
 								},
@@ -879,6 +902,11 @@ func TestTranslateBootDevice(t *testing.T) {
 									Label:    util.StrToPtr("prep-2"),
 									SizeMiB:  util.IntToPtr(prepV1SizeMiB),
 									TypeGUID: util.StrToPtr(prepTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("reserved-2"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
 								},
 								{
 									Label:   util.StrToPtr("boot-2"),
@@ -950,9 +978,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0)},
@@ -963,9 +995,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1)},
@@ -1266,6 +1302,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	// The partition sizes of existing layouts must never change, but
 	// we use the constants in tests for clarity.  Ensure no one has
 	// changed them.
+	assert.Equal(t, reservedV1SizeMiB, 1)
 	assert.Equal(t, biosV1SizeMiB, 1)
 	assert.Equal(t, prepV1SizeMiB, 4)
 	assert.Equal(t, espV1SizeMiB, 127)

--- a/config/fcos/v1_5_exp/translate.go
+++ b/config/fcos/v1_5_exp/translate.go
@@ -29,18 +29,14 @@ import (
 )
 
 const (
-	biosTypeGuid = "21686148-6449-6E6F-744E-656564454649"
-	prepTypeGuid = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
-	espTypeGuid  = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+	reservedTypeGuid = "8DA63339-0007-60C0-C436-083AC8230908"
+	biosTypeGuid     = "21686148-6449-6E6F-744E-656564454649"
+	prepTypeGuid     = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
+	espTypeGuid      = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
 
 	// The partition layout implemented in this file replicates
 	// the layout of the OS image defined in:
 	// https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh
-	//
-	// Exception: we don't try to skip unused partition numbers,
-	// because specifying a partition number would prevent child
-	// configs from overriding partition fields using the partition
-	// label as the lookup key.
 	//
 	// It's not critical that we match that layout exactly; the hard
 	// constraints are:
@@ -51,10 +47,11 @@ const (
 	//
 	// Do not change these constants!  New partition layouts must be
 	// encoded into new layout templates.
-	biosV1SizeMiB = 1
-	prepV1SizeMiB = 4
-	espV1SizeMiB  = 127
-	bootV1SizeMiB = 384
+	reservedV1SizeMiB = 1
+	biosV1SizeMiB     = 1
+	prepV1SizeMiB     = 4
+	espV1SizeMiB      = 127
+	bootV1SizeMiB     = 384
 )
 
 // ToIgn3_4Unvalidated translates the config to an Ignition config.  It also
@@ -131,12 +128,17 @@ func (c Config) processBootDevice(config *types.Config, ts *translate.Translatio
 					SizeMiB:  util.IntToPtr(biosV1SizeMiB),
 					TypeGUID: util.StrToPtr(biosTypeGuid),
 				})
-			}
-			if wantPRePPart {
+			} else if wantPRePPart {
 				disk.Partitions = append(disk.Partitions, types.Partition{
 					Label:    util.StrToPtr(fmt.Sprintf("prep-%d", labelIndex)),
 					SizeMiB:  util.IntToPtr(prepV1SizeMiB),
 					TypeGUID: util.StrToPtr(prepTypeGuid),
+				})
+			} else {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("reserved-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+					TypeGUID: util.StrToPtr(reservedTypeGuid),
 				})
 			}
 			if wantEFIPart {
@@ -144,6 +146,12 @@ func (c Config) processBootDevice(config *types.Config, ts *translate.Translatio
 					Label:    util.StrToPtr(fmt.Sprintf("esp-%d", labelIndex)),
 					SizeMiB:  util.IntToPtr(espV1SizeMiB),
 					TypeGUID: util.StrToPtr(espTypeGuid),
+				})
+			} else {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("reserved-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+					TypeGUID: util.StrToPtr(reservedTypeGuid),
 				})
 			}
 			disk.Partitions = append(disk.Partitions, types.Partition{

--- a/config/fcos/v1_5_exp/translate_test.go
+++ b/config/fcos/v1_5_exp/translate_test.go
@@ -656,6 +656,11 @@ func TestTranslateBootDevice(t *testing.T) {
 							Device: "/dev/vda",
 							Partitions: []types.Partition{
 								{
+									Label:    util.StrToPtr("reserved-1"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
+								{
 									Label:    util.StrToPtr("esp-1"),
 									SizeMiB:  util.IntToPtr(espV1SizeMiB),
 									TypeGUID: util.StrToPtr(espTypeGuid),
@@ -673,6 +678,11 @@ func TestTranslateBootDevice(t *testing.T) {
 						{
 							Device: "/dev/vdb",
 							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("reserved-2"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
 								{
 									Label:    util.StrToPtr("esp-2"),
 									SizeMiB:  util.IntToPtr(espV1SizeMiB),
@@ -758,9 +768,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0)},
@@ -776,9 +790,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1)},
@@ -863,6 +881,11 @@ func TestTranslateBootDevice(t *testing.T) {
 									TypeGUID: util.StrToPtr(prepTypeGuid),
 								},
 								{
+									Label:    util.StrToPtr("reserved-1"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
+								},
+								{
 									Label:   util.StrToPtr("boot-1"),
 									SizeMiB: util.IntToPtr(bootV1SizeMiB),
 								},
@@ -879,6 +902,11 @@ func TestTranslateBootDevice(t *testing.T) {
 									Label:    util.StrToPtr("prep-2"),
 									SizeMiB:  util.IntToPtr(prepV1SizeMiB),
 									TypeGUID: util.StrToPtr(prepTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("reserved-2"),
+									SizeMiB:  util.IntToPtr(reservedV1SizeMiB),
+									TypeGUID: util.StrToPtr(reservedTypeGuid),
 								},
 								{
 									Label:   util.StrToPtr("boot-2"),
@@ -950,9 +978,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0)},
@@ -963,9 +995,13 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2)},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3)},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
 				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1)},
@@ -1266,6 +1302,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	// The partition sizes of existing layouts must never change, but
 	// we use the constants in tests for clarity.  Ensure no one has
 	// changed them.
+	assert.Equal(t, reservedV1SizeMiB, 1)
 	assert.Equal(t, biosV1SizeMiB, 1)
 	assert.Equal(t, prepV1SizeMiB, 4)
 	assert.Equal(t, espV1SizeMiB, 127)


### PR DESCRIPTION
On aarch64 and ppc64le, FCOS and RHCOS have added reserved partitions to keep partition numbers consistent between arches.  Add those partitions to the boot device mirror templates, including in stable specs.  This shouldn't introduce compatibility problems: transposefs in older OS releases will ignore the reserved partitions, any configs relying on partition numbers should be specifying them explicitly, and in any event this only affects secondary arches.

Details in https://github.com/coreos/fedora-coreos-tracker/issues/855.