### PR TITLE
config/fcos: warn if the partition number for root isn't correct

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -50,6 +50,9 @@ var (
 	ErrUnknownBootDeviceLayout = errors.New("layout must be one of: aarch64, ppc64le, x86_64")
 	ErrTooFewMirrorDevices     = errors.New("mirroring requires at least two devices")
 
+	// partition
+	ErrWrongPartitionNumber = errors.New("incorrect partition number; a new partition will be created using reserved label")
+
 	// MachineConfigs
 	ErrFieldElided            = errors.New("field ignored in raw mode")
 	ErrNameRequired           = errors.New("metadata.name is required")

--- a/config/fcos/v1_3/translate_test.go
+++ b/config/fcos/v1_3/translate_test.go
@@ -37,6 +37,7 @@ func TestTranslateBootDevice(t *testing.T) {
 		in         Config
 		out        types.Config
 		exceptions []translate.Translation
+		report     report.Report
 	}{
 		// empty config
 		{
@@ -48,6 +49,100 @@ func TestTranslateBootDevice(t *testing.T) {
 			},
 			[]translate.Translation{
 				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+			},
+			report.Report{},
+		},
+		// partition number for the `root` label is incorrect
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										SizeMiB: util.IntToPtr(12000),
+										Resize:  util.BoolToPtr(true),
+									},
+									{
+										Label:   util.StrToPtr("var-home"),
+										SizeMiB: util.IntToPtr(10240),
+									},
+								},
+							},
+						},
+						Filesystems: []base.Filesystem{
+							{
+								Device:         "/dev/disk/by-partlabel/var-home",
+								Format:         util.StrToPtr("xfs"),
+								Path:           util.StrToPtr("/var/home"),
+								Label:          util.StrToPtr("var-home"),
+								WipeFilesystem: util.BoolToPtr(false),
+							},
+						},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:   util.StrToPtr("root"),
+									SizeMiB: util.IntToPtr(12000),
+									Resize:  util.BoolToPtr(true),
+								},
+								{
+									Label:   util.StrToPtr("var-home"),
+									SizeMiB: util.IntToPtr(10240),
+								},
+							},
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/disk/by-partlabel/var-home",
+							Format:         util.StrToPtr("xfs"),
+							Path:           util.StrToPtr("/var/home"),
+							Label:          util.StrToPtr("var-home"),
+							WipeFilesystem: util.BoolToPtr(false),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "resize"), path.New("json", "storage", "disks", 0, "partitions", 0, "resize")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "label"), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
+				{path.New("yaml", "storage", "disks", 0), path.New("json", "storage", "disks", 0)},
+				{path.New("yaml", "storage", "filesystems", 0, "device"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "storage", "filesystems", 0, "format"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "storage", "filesystems", 0, "path"), path.New("json", "storage", "filesystems", 0, "path")},
+				{path.New("yaml", "storage", "filesystems", 0, "label"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "storage", "filesystems", 0, "wipe_filesystem"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "storage", "filesystems", 0), path.New("json", "storage", "filesystems", 0)},
+				{path.New("yaml", "storage", "filesystems"), path.New("json", "storage", "filesystems")},
+				{path.New("yaml", "storage"), path.New("json", "storage")},
+			},
+			report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrWrongPartitionNumber.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
 			},
 		},
 		// LUKS, x86_64
@@ -118,6 +213,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 3-disk mirror, x86_64
 		{
@@ -354,6 +450,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 3-disk mirror + LUKS, x86_64
 		{
@@ -627,6 +724,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 2-disk mirror + LUKS, aarch64
 		{
@@ -847,6 +945,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 2-disk mirror + LUKS, ppc64le
 		{
@@ -1047,6 +1146,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 2-disk mirror + LUKS with overridden root partition size
 		// and filesystem type, x86_64
@@ -1296,6 +1396,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "storage", "filesystems"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "storage"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 	}
 
@@ -1311,7 +1412,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
 		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		assert.Equal(t, test.report, r, "#%d: report mismatch", i)
 		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
 		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
 	}

--- a/config/fcos/v1_4/translate.go
+++ b/config/fcos/v1_4/translate.go
@@ -64,6 +64,20 @@ func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Conf
 		return types.Config{}, translate.TranslationSet{}, r
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
+	for i, disk := range ret.Storage.Disks {
+		// In the boot_device.mirror case, nothing specifies partition numbers
+		// so match existing partitions only when `wipeTable` is false
+		if disk.WipeTable == nil {
+			for j, partition := range disk.Partitions {
+				// check for reserved partlabels
+				if partition.Label != nil {
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+			}
+		}
+	}
 	return ret, ts, r
 }
 

--- a/config/fcos/v1_5_exp/translate.go
+++ b/config/fcos/v1_5_exp/translate.go
@@ -64,6 +64,20 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 		return types.Config{}, translate.TranslationSet{}, r
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
+	for i, disk := range ret.Storage.Disks {
+		// In the boot_device.mirror case, nothing specifies partition numbers
+		// so match existing partitions only when `wipeTable` is false
+		if disk.WipeTable == nil {
+			for j, partition := range disk.Partitions {
+				// check for reserved partlabels
+				if partition.Label != nil {
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+			}
+		}
+	}
 	return ret, ts, r
 }
 

--- a/config/fcos/v1_5_exp/translate_test.go
+++ b/config/fcos/v1_5_exp/translate_test.go
@@ -37,6 +37,7 @@ func TestTranslateBootDevice(t *testing.T) {
 		in         Config
 		out        types.Config
 		exceptions []translate.Translation
+		report     report.Report
 	}{
 		// empty config
 		{
@@ -48,6 +49,100 @@ func TestTranslateBootDevice(t *testing.T) {
 			},
 			[]translate.Translation{
 				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+			},
+			report.Report{},
+		},
+		// partition number for the `root` label is incorrect
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										SizeMiB: util.IntToPtr(12000),
+										Resize:  util.BoolToPtr(true),
+									},
+									{
+										Label:   util.StrToPtr("var-home"),
+										SizeMiB: util.IntToPtr(10240),
+									},
+								},
+							},
+						},
+						Filesystems: []base.Filesystem{
+							{
+								Device:         "/dev/disk/by-partlabel/var-home",
+								Format:         util.StrToPtr("xfs"),
+								Path:           util.StrToPtr("/var/home"),
+								Label:          util.StrToPtr("var-home"),
+								WipeFilesystem: util.BoolToPtr(false),
+							},
+						},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.4.0-experimental",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:   util.StrToPtr("root"),
+									SizeMiB: util.IntToPtr(12000),
+									Resize:  util.BoolToPtr(true),
+								},
+								{
+									Label:   util.StrToPtr("var-home"),
+									SizeMiB: util.IntToPtr(10240),
+								},
+							},
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/disk/by-partlabel/var-home",
+							Format:         util.StrToPtr("xfs"),
+							Path:           util.StrToPtr("/var/home"),
+							Label:          util.StrToPtr("var-home"),
+							WipeFilesystem: util.BoolToPtr(false),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "resize"), path.New("json", "storage", "disks", 0, "partitions", 0, "resize")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "label"), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
+				{path.New("yaml", "storage", "disks", 0), path.New("json", "storage", "disks", 0)},
+				{path.New("yaml", "storage", "filesystems", 0, "device"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "storage", "filesystems", 0, "format"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "storage", "filesystems", 0, "path"), path.New("json", "storage", "filesystems", 0, "path")},
+				{path.New("yaml", "storage", "filesystems", 0, "label"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "storage", "filesystems", 0, "wipe_filesystem"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "storage", "filesystems", 0), path.New("json", "storage", "filesystems", 0)},
+				{path.New("yaml", "storage", "filesystems"), path.New("json", "storage", "filesystems")},
+				{path.New("yaml", "storage"), path.New("json", "storage")},
+			},
+			report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrWrongPartitionNumber.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
 			},
 		},
 		// LUKS, x86_64
@@ -118,6 +213,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 3-disk mirror, x86_64
 		{
@@ -354,6 +450,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 3-disk mirror + LUKS, x86_64
 		{
@@ -627,6 +724,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 2-disk mirror + LUKS, aarch64
 		{
@@ -847,6 +945,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 2-disk mirror + LUKS, ppc64le
 		{
@@ -1047,6 +1146,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "boot_device"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 		// 2-disk mirror + LUKS with overridden root partition size
 		// and filesystem type, x86_64
@@ -1296,6 +1396,7 @@ func TestTranslateBootDevice(t *testing.T) {
 				{path.New("yaml", "storage", "filesystems"), path.New("json", "storage", "filesystems")},
 				{path.New("yaml", "storage"), path.New("json", "storage")},
 			},
+			report.Report{},
 		},
 	}
 
@@ -1311,7 +1412,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
 		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		assert.Equal(t, test.report, r, "#%d: report mimatch", i)
 		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
 		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
 	}


### PR DESCRIPTION
Fixes https://github.com/coreos/butane/issues/243

This change warns if the partition number for the `root` label is not specified or wrongly mentioned.