### PR TITLE
docs: Small fixes

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,11 @@ url: "https://coreos.github.io"
 # Comment above and use below for local development
 # url: "http://localhost:4000"
 permalink: /:title/
+markdown: kramdown
+kramdown:
+  typographic_symbols:
+    ndash: "--"
+    mdash: "---"
 
 remote_theme: coreos/just-the-docs
 plugins:

--- a/docs/config-fcos-v1_0.md
+++ b/docs/config-fcos-v1_0.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Fedora CoreOS v1.0.0
 parent: Configuration specifications
 nav_order: 49

--- a/docs/config-fcos-v1_1.md
+++ b/docs/config-fcos-v1_1.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Fedora CoreOS v1.1.0
 parent: Configuration specifications
 nav_order: 48

--- a/docs/config-fcos-v1_2.md
+++ b/docs/config-fcos-v1_2.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Fedora CoreOS v1.2.0
 parent: Configuration specifications
 nav_order: 47

--- a/docs/config-fcos-v1_3.md
+++ b/docs/config-fcos-v1_3.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Fedora CoreOS v1.3.0
 parent: Configuration specifications
 nav_order: 46

--- a/docs/config-fcos-v1_4.md
+++ b/docs/config-fcos-v1_4.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Fedora CoreOS v1.4.0
 parent: Configuration specifications
 nav_order: 45

--- a/docs/config-fcos-v1_5-exp.md
+++ b/docs/config-fcos-v1_5-exp.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Fedora CoreOS v1.5.0-experimental
 parent: Configuration specifications
 nav_order: 50

--- a/docs/config-openshift-v4_10-exp.md
+++ b/docs/config-openshift-v4_10-exp.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: OpenShift v4.10.0-experimental
 parent: Configuration specifications
 nav_order: 100

--- a/docs/config-openshift-v4_8.md
+++ b/docs/config-openshift-v4_8.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: OpenShift v4.8.0
 parent: Configuration specifications
 nav_order: 98

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: OpenShift v4.9.0
 parent: Configuration specifications
 nav_order: 97

--- a/docs/config-rhcos-v0_1.md
+++ b/docs/config-rhcos-v0_1.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: RHEL CoreOS v0.1.0
 parent: Configuration specifications
 nav_order: 99

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 9
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 3
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 2
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 nav_order: 1
 ---
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 has_children: true
 nav_order: 4
 has_toc: false

--- a/docs/upgrading-fcos.md
+++ b/docs/upgrading-fcos.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Fedora CoreOS
 parent: Upgrading configs
 nav_order: 1

--- a/docs/upgrading-openshift.md
+++ b/docs/upgrading-openshift.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: OpenShift
 parent: Upgrading configs
 nav_order: 2

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 has_children: true
 nav_order: 5
 has_toc: false


### PR DESCRIPTION
docs: Do not convert -- & --- to en/em-dash

'--' is frequently used for command line options and was thus
incorrectly rendered as a special en-dash symbol.

---

docs: Remove default layout from front matter

No need to specify it as it is the default.