### PR TITLE
rhcos: add deprecation warning

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -27,6 +27,9 @@ var (
 	ErrInvalidSourceConfig    = errors.New("source config is invalid")
 	ErrInvalidGeneratedConfig = errors.New("config generated was invalid")
 
+	// deprecated variant/version
+	ErrRhcosVariantDeprecated = errors.New("this variant is deprecated and will be removed in a future release; use openshift variant instead")
+
 	// resources and trees
 	ErrTooManyResourceSources = errors.New("only one of the following can be set: inline, local, source")
 	ErrFilesDirEscape         = errors.New("local file path traverses outside the files directory")

--- a/config/rhcos/v0_1/translate.go
+++ b/config/rhcos/v0_1/translate.go
@@ -19,6 +19,7 @@ import (
 	cutil "github.com/coreos/butane/config/util"
 
 	"github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -28,6 +29,7 @@ import (
 // an error is returned.
 func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.Report, error) {
 	cfg, r, err := cutil.Translate(c, "ToIgn3_2Unvalidated", options)
+	r.AddOnWarn(path.New("yaml", "variant"), common.ErrRhcosVariantDeprecated)
 	return cfg.(types.Config), r, err
 }
 


### PR DESCRIPTION
#256 marked the `rhcos` variant deprecated, but we're still seeing folks try to use it in new applications.  Add a warning when the variant is used.