### PR TITLE
templates: skip vendoring the new version in favor of dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -57,4 +57,3 @@ Housekeeping:
    - [ ] When the PR lands, build the package
  - [ ] File ticket similar to [this one](https://issues.redhat.com/browse/ART-3043) to sync the new version to mirror.openshift.com
  - [ ] Ask bgilbert to update the [MacPorts package](https://github.com/macports/macports-ports/tree/master/sysutils/butane)
- - [ ] Vendor the new Butane version in [mantle](https://github.com/coreos/coreos-assembler/tree/main/mantle)


### PR DESCRIPTION
No need to vendor the new Butane version in mantle after [this](https://github.com/coreos/coreos-assembler/pull/2529) PR