### PR TITLE
openshift/v4_10_exp: re-enable file compression

### DIFF
--- a/config/openshift/v4_10_exp/translate.go
+++ b/config/openshift/v4_10_exp/translate.go
@@ -41,10 +41,6 @@ const (
 // can be tracked back to their source in the source config.  No config
 // validation is performed on input or output.
 func (c Config) ToMachineConfig4_10Unvalidated(options common.TranslateOptions) (result.MachineConfig, translate.TranslationSet, report.Report) {
-	// disable inline resource compression since the MCO doesn't support it
-	// https://bugzilla.redhat.com/show_bug.cgi?id=1970218
-	options.NoResourceAutoCompression = true
-
 	cfg, ts, r := c.Config.ToIgn3_4Unvalidated(options)
 	if r.IsFatal() {
 		return result.MachineConfig{}, ts, r
@@ -223,10 +219,6 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 	// is provisioned, and the struct contains unsupported fields, MCD
 	// will mark the node degraded, even if the change only affects
 	// supported fields.  We reject these.
-	//
-	// BUGGED - Ignored by the MCD but not by Ignition.  Ignition
-	// correctly applies the setting, but the MCD doesn't, and writes
-	// incorrect state to the node.
 
 	var r report.Report
 	for i, fs := range mc.Spec.Config.Storage.Filesystems {
@@ -243,11 +235,6 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 		if len(file.Append) > 0 {
 			// FORBIDDEN
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "append"), common.ErrFileAppendSupport)
-		}
-		if util.NotEmpty(file.Contents.Compression) {
-			// BUGGED
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1970218
-			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "compression"), common.ErrFileCompressionSupport)
 		}
 	}
 	for i := range mc.Spec.Config.Storage.Links {

--- a/config/openshift/v4_10_exp/translate_test.go
+++ b/config/openshift/v4_10_exp/translate_test.go
@@ -55,7 +55,6 @@ func TestElidedFieldWarning(t *testing.T) {
 }
 
 func TestTranslateConfig(t *testing.T) {
-	zzz := "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 	tests := []struct {
 		in         Config
 		out        result.MachineConfig
@@ -95,76 +94,6 @@ func TestTranslateConfig(t *testing.T) {
 				{path.New("yaml"), path.New("json", "spec", "config")},
 				{path.New("yaml", "ignition"), path.New("json", "spec", "config", "ignition")},
 				{path.New("yaml", "version"), path.New("json", "spec", "config", "ignition", "version")},
-			},
-		},
-		// ensure automatic compression is disabled
-		{
-			Config{
-				Metadata: Metadata{
-					Name: "z",
-					Labels: map[string]string{
-						ROLE_LABEL_KEY: "z",
-					},
-				},
-				Config: fcos.Config{
-					Config: base.Config{
-						Storage: base.Storage{
-							Files: []base.File{
-								{
-									Path: "/z",
-									Contents: base.Resource{
-										Inline: util.StrToPtr(zzz),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			result.MachineConfig{
-				ApiVersion: result.MC_API_VERSION,
-				Kind:       result.MC_KIND,
-				Metadata: result.Metadata{
-					Name: "z",
-					Labels: map[string]string{
-						ROLE_LABEL_KEY: "z",
-					},
-				},
-				Spec: result.Spec{
-					Config: types.Config{
-						Ignition: types.Ignition{
-							Version: "3.4.0-experimental",
-						},
-						Storage: types.Storage{
-							Files: []types.File{
-								{
-									Node: types.Node{
-										Path: "/z",
-									},
-									FileEmbedded1: types.FileEmbedded1{
-										Contents: types.Resource{
-											Source: util.StrToPtr("data:," + zzz),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			[]translate.Translation{
-				{path.New("yaml", "version"), path.New("json", "apiVersion")},
-				{path.New("yaml", "version"), path.New("json", "kind")},
-				{path.New("yaml", "version"), path.New("json", "spec")},
-				{path.New("yaml"), path.New("json", "spec", "config")},
-				{path.New("yaml", "ignition"), path.New("json", "spec", "config", "ignition")},
-				{path.New("yaml", "version"), path.New("json", "spec", "config", "ignition", "version")},
-				{path.New("yaml", "storage"), path.New("json", "spec", "config", "storage")},
-				{path.New("yaml", "storage", "files"), path.New("json", "spec", "config", "storage", "files")},
-				{path.New("yaml", "storage", "files", 0), path.New("json", "spec", "config", "storage", "files", 0)},
-				{path.New("yaml", "storage", "files", 0, "path"), path.New("json", "spec", "config", "storage", "files", 0, "path")},
-				{path.New("yaml", "storage", "files", 0, "contents"), path.New("json", "spec", "config", "storage", "files", 0, "contents")},
-				{path.New("yaml", "storage", "files", 0, "contents", "inline"), path.New("json", "spec", "config", "storage", "files", 0, "contents", "source")},
 			},
 		},
 		// FIPS
@@ -422,10 +351,6 @@ func TestValidateSupport(t *testing.T) {
 											Inline: util.StrToPtr("z"),
 										},
 									},
-									Contents: base.Resource{
-										Inline:      util.StrToPtr("z"),
-										Compression: util.StrToPtr("gzip"),
-									},
 								},
 							},
 							Filesystems: []base.Filesystem{
@@ -496,7 +421,6 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrFilesystemNoneSupport, path.New("yaml", "storage", "filesystems", 1, "format")},
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
-				{report.Error, common.ErrFileCompressionSupport, path.New("yaml", "storage", "files", 1, "contents", "compression")},
 				{report.Error, common.ErrLinkSupport, path.New("yaml", "storage", "links", 0)},
 				{report.Error, common.ErrGroupSupport, path.New("yaml", "passwd", "groups", 0)},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "gecos")},


### PR DESCRIPTION
https://github.com/openshift/machine-config-operator/pull/2820 adds file compression support to the MCO.  Allow it to be enabled in a config, either explicitly or automatically.

This reverts 023fdd41adbb and part of e29e373b4645 for 4.10.0-exp.