### PR TITLE
docs/config-*: ignition section is optional

### DIFF
--- a/docs/config-fcos-v1_0.md
+++ b/docs/config-fcos-v1_0.md
@@ -10,7 +10,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.0.0` and generates Ignition configs with version `3.0.0`.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.

--- a/docs/config-fcos-v1_1.md
+++ b/docs/config-fcos-v1_1.md
@@ -10,7 +10,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.1.0` and generates Ignition configs with version `3.1.0`.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-fcos-v1_2.md
+++ b/docs/config-fcos-v1_2.md
@@ -10,7 +10,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.2.0` and generates Ignition configs with version `3.2.0`.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-fcos-v1_3.md
+++ b/docs/config-fcos-v1_3.md
@@ -10,7 +10,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.3.0` and generates Ignition configs with version `3.2.0`.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-fcos-v1_4.md
+++ b/docs/config-fcos-v1_4.md
@@ -10,7 +10,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.4.0` and generates Ignition configs with version `3.3.0`.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-fcos-v1_5-exp.md
+++ b/docs/config-fcos-v1_5-exp.md
@@ -12,7 +12,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.5.0-experimental` and generates Ignition configs with version `3.4.0-experimental`.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-openshift-v4_10-exp.md
+++ b/docs/config-openshift-v4_10-exp.md
@@ -15,7 +15,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
   * **name** (string): a unique [name][k8s-names] for this MachineConfig resource.
   * **labels** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource. `machineconfiguration.openshift.io/role` is required.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-openshift-v4_8.md
+++ b/docs/config-openshift-v4_8.md
@@ -13,7 +13,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
   * **name** (string): a unique [name][k8s-names] for this MachineConfig resource.
   * **labels** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource. `machineconfiguration.openshift.io/role` is required.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -13,7 +13,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
   * **name** (string): a unique [name][k8s-names] for this MachineConfig resource.
   * **labels** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource. `machineconfiguration.openshift.io/role` is required.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.

--- a/docs/config-rhcos-v0_1.md
+++ b/docs/config-rhcos-v0_1.md
@@ -10,7 +10,7 @@ The RHEL CoreOS configuration is a YAML document conforming to the following spe
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `rhcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `0.1.0` and generates Ignition configs with version `3.2.0`.
-* **ignition** (object): metadata about the configuration itself.
+* **_ignition_** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
       * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.


### PR DESCRIPTION
It's mandatory for Ignition configs, but optional for Butane configs.

Reported by @Nemric.