### PR TITLE
docs: Don't use '--tty-' for butane alias

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ podman run --rm -v /path/to/your_config.bu:/config.bu:z quay.io/coreos/butane:re
 You may also add the following alias in your shell configuration:
 
 ```
-alias butane='podman run --rm --tty --interactive \
+alias butane='podman run --rm --interactive       \
               --security-opt label=disable        \
               --volume ${PWD}:/pwd --workdir /pwd \
               quay.io/coreos/butane:release'


### PR DESCRIPTION
Using '--tty' conflicts with stdin redirection:
https://docs.podman.io/en/latest/markdown/podman-run.1.html#tty-t