### PR TITLE
openshift/*: reject `storage.files.contents.source` with non-`data` URL

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -61,6 +61,7 @@ var (
 	ErrBtrfsSupport           = errors.New("btrfs is not supported in this spec version")
 	ErrFilesystemNoneSupport  = errors.New("format \"none\" is not supported in this spec version")
 	ErrDirectorySupport       = errors.New("directories are not supported in this spec version")
+	ErrFileSchemeSupport      = errors.New("file contents source must be data URL in this spec version")
 	ErrFileAppendSupport      = errors.New("appending to files is not supported in this spec version")
 	ErrFileCompressionSupport = errors.New("file compression is not supported in this spec version")
 	ErrLinkSupport            = errors.New("links are not supported in this spec version")

--- a/config/openshift/v4_10_exp/translate.go
+++ b/config/openshift/v4_10_exp/translate.go
@@ -15,6 +15,7 @@
 package v4_10_exp
 
 import (
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -235,6 +236,14 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 		if len(file.Append) > 0 {
 			// FORBIDDEN
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "append"), common.ErrFileAppendSupport)
+		}
+		if file.Contents.Source != nil {
+			url, err := url.Parse(*file.Contents.Source)
+			// parse errors will be caught by normal config validation
+			if err == nil && url.Scheme != "data" {
+				// FORBIDDEN
+				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
+			}
 		}
 	}
 	for i := range mc.Spec.Config.Storage.Links {

--- a/config/openshift/v4_10_exp/translate_test.go
+++ b/config/openshift/v4_10_exp/translate_test.go
@@ -328,6 +328,32 @@ func TestValidateSupport(t *testing.T) {
 			},
 			[]entry{},
 		},
+		// valid data URL
+		{
+			Config{
+				Metadata: Metadata{
+					Name: "z",
+					Labels: map[string]string{
+						ROLE_LABEL_KEY: "z",
+					},
+				},
+				Config: fcos.Config{
+					Config: base.Config{
+						Storage: base.Storage{
+							Files: []base.File{
+								{
+									Path: "/f",
+									Contents: base.Resource{
+										Source: util.StrToPtr("data:,foo"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			[]entry{},
+		},
 		// all the warnings/errors
 		{
 			Config{
@@ -350,6 +376,12 @@ func TestValidateSupport(t *testing.T) {
 										{
 											Inline: util.StrToPtr("z"),
 										},
+									},
+								},
+								{
+									Path: "/h",
+									Contents: base.Resource{
+										Source: util.StrToPtr("https://example.com/"),
 									},
 								},
 							},
@@ -421,6 +453,7 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrFilesystemNoneSupport, path.New("yaml", "storage", "filesystems", 1, "format")},
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
+				{report.Error, common.ErrFileSchemeSupport, path.New("yaml", "storage", "files", 2, "contents", "source")},
 				{report.Error, common.ErrLinkSupport, path.New("yaml", "storage", "links", 0)},
 				{report.Error, common.ErrGroupSupport, path.New("yaml", "passwd", "groups", 0)},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "gecos")},

--- a/config/openshift/v4_8/translate.go
+++ b/config/openshift/v4_8/translate.go
@@ -15,6 +15,7 @@
 package v4_8
 
 import (
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -235,6 +236,14 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			// BUGGED
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1970218
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "compression"), common.ErrFileCompressionSupport)
+		}
+		if file.Contents.Source != nil {
+			url, err := url.Parse(*file.Contents.Source)
+			// parse errors will be caught by normal config validation
+			if err == nil && url.Scheme != "data" {
+				// FORBIDDEN
+				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
+			}
 		}
 	}
 	for i := range mc.Spec.Config.Storage.Links {

--- a/config/openshift/v4_8/translate_test.go
+++ b/config/openshift/v4_8/translate_test.go
@@ -399,6 +399,32 @@ func TestValidateSupport(t *testing.T) {
 			},
 			[]entry{},
 		},
+		// valid data URL
+		{
+			Config{
+				Metadata: Metadata{
+					Name: "z",
+					Labels: map[string]string{
+						ROLE_LABEL_KEY: "z",
+					},
+				},
+				Config: fcos.Config{
+					Config: base.Config{
+						Storage: base.Storage{
+							Files: []base.File{
+								{
+									Path: "/f",
+									Contents: base.Resource{
+										Source: util.StrToPtr("data:,foo"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			[]entry{},
+		},
 		// all the warnings/errors
 		{
 			Config{
@@ -425,6 +451,12 @@ func TestValidateSupport(t *testing.T) {
 									Contents: base.Resource{
 										Inline:      util.StrToPtr("z"),
 										Compression: util.StrToPtr("gzip"),
+									},
+								},
+								{
+									Path: "/h",
+									Contents: base.Resource{
+										Source: util.StrToPtr("https://example.com/"),
 									},
 								},
 							},
@@ -484,6 +516,7 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
 				{report.Error, common.ErrFileCompressionSupport, path.New("yaml", "storage", "files", 1, "contents", "compression")},
+				{report.Error, common.ErrFileSchemeSupport, path.New("yaml", "storage", "files", 2, "contents", "source")},
 				{report.Error, common.ErrLinkSupport, path.New("yaml", "storage", "links", 0)},
 				{report.Error, common.ErrGroupSupport, path.New("yaml", "passwd", "groups", 0)},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "gecos")},

--- a/config/openshift/v4_9/translate.go
+++ b/config/openshift/v4_9/translate.go
@@ -15,6 +15,7 @@
 package v4_9
 
 import (
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -235,6 +236,14 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			// BUGGED
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1970218
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "compression"), common.ErrFileCompressionSupport)
+		}
+		if file.Contents.Source != nil {
+			url, err := url.Parse(*file.Contents.Source)
+			// parse errors will be caught by normal config validation
+			if err == nil && url.Scheme != "data" {
+				// FORBIDDEN
+				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
+			}
 		}
 	}
 	for i := range mc.Spec.Config.Storage.Links {

--- a/config/openshift/v4_9/translate_test.go
+++ b/config/openshift/v4_9/translate_test.go
@@ -399,6 +399,32 @@ func TestValidateSupport(t *testing.T) {
 			},
 			[]entry{},
 		},
+		// valid data URL
+		{
+			Config{
+				Metadata: Metadata{
+					Name: "z",
+					Labels: map[string]string{
+						ROLE_LABEL_KEY: "z",
+					},
+				},
+				Config: fcos.Config{
+					Config: base.Config{
+						Storage: base.Storage{
+							Files: []base.File{
+								{
+									Path: "/f",
+									Contents: base.Resource{
+										Source: util.StrToPtr("data:,foo"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			[]entry{},
+		},
 		// all the warnings/errors
 		{
 			Config{
@@ -425,6 +451,12 @@ func TestValidateSupport(t *testing.T) {
 									Contents: base.Resource{
 										Inline:      util.StrToPtr("z"),
 										Compression: util.StrToPtr("gzip"),
+									},
+								},
+								{
+									Path: "/h",
+									Contents: base.Resource{
+										Source: util.StrToPtr("https://example.com/"),
 									},
 								},
 							},
@@ -484,6 +516,7 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
 				{report.Error, common.ErrFileCompressionSupport, path.New("yaml", "storage", "files", 1, "contents", "compression")},
+				{report.Error, common.ErrFileSchemeSupport, path.New("yaml", "storage", "files", 2, "contents", "source")},
 				{report.Error, common.ErrLinkSupport, path.New("yaml", "storage", "links", 0)},
 				{report.Error, common.ErrGroupSupport, path.New("yaml", "passwd", "groups", 0)},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "gecos")},

--- a/docs/config-openshift-v4_10-exp.md
+++ b/docs/config-openshift-v4_10-exp.md
@@ -88,12 +88,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
-      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_source_** (string): the URL of the file contents. Only the [`data`][rfc2397] scheme is supported. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
-      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
-        * **name** (string): the header name.
-        * **_value_** (string): the header contents.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.

--- a/docs/config-openshift-v4_8.md
+++ b/docs/config-openshift-v4_8.md
@@ -86,12 +86,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
-      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_source_** (string): the URL of the file contents. Only the [`data`][rfc2397] scheme is supported. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
-      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
-        * **name** (string): the header name.
-        * **_value_** (string): the header contents.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -86,12 +86,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
-      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_source_** (string): the URL of the file contents. Only the [`data`][rfc2397] scheme is supported. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
-      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
-        * **name** (string): the header name.
-        * **_value_** (string): the header contents.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.


### PR DESCRIPTION
The MCO fails on a parse error when attempting to reconcile a file sourced from a URL scheme other than `data`.  Reject such URLs, including in stable specs.

Drop `http_headers` from the spec docs, since it doesn't make sense for data URLs.  Ignition config validation already rejects the field in this case.

cc @yuqi-zhang to confirm that this is the right thing to do.