### PR TITLE
openshift/v4_10: roll back to Ignition spec 3.2.0

### DIFF
--- a/config/openshift/v4_10/result/schema.go
+++ b/config/openshift/v4_10/result/schema.go
@@ -15,7 +15,7 @@
 package result
 
 import (
-	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 )
 
 const (

--- a/config/openshift/v4_10/schema.go
+++ b/config/openshift/v4_10/schema.go
@@ -15,7 +15,7 @@
 package v4_10
 
 import (
-	fcos "github.com/coreos/butane/config/fcos/v1_5_exp"
+	fcos "github.com/coreos/butane/config/fcos/v1_3"
 )
 
 const ROLE_LABEL_KEY = "machineconfiguration.openshift.io/role"

--- a/config/openshift/v4_10/translate.go
+++ b/config/openshift/v4_10/translate.go
@@ -25,7 +25,7 @@ import (
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
@@ -42,7 +42,7 @@ const (
 // can be tracked back to their source in the source config.  No config
 // validation is performed on input or output.
 func (c Config) ToMachineConfig4_10Unvalidated(options common.TranslateOptions) (result.MachineConfig, translate.TranslationSet, report.Report) {
-	cfg, ts, r := c.Config.ToIgn3_4Unvalidated(options)
+	cfg, ts, r := c.Config.ToIgn3_2Unvalidated(options)
 	if r.IsFatal() {
 		return result.MachineConfig{}, ts, r
 	}
@@ -102,11 +102,11 @@ func (c Config) ToMachineConfig4_10(options common.TranslateOptions) (result.Mac
 	return cfg.(result.MachineConfig), r, err
 }
 
-// ToIgn3_4Unvalidated translates the config to an Ignition config.  It also
+// ToIgn3_2Unvalidated translates the config to an Ignition config.  It also
 // returns the set of translations it did so paths in the resultant config
 // can be tracked back to their source in the source config.  No config
 // validation is performed on input or output.
-func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
 	mc, ts, r := c.ToMachineConfig4_10Unvalidated(options)
 	cfg := mc.Spec.Config
 
@@ -121,12 +121,12 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 	return cfg, ts, r
 }
 
-// ToIgn3_4 translates the config to an Ignition config.  It returns a
+// ToIgn3_2 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If
 // the report has fatal errors or it encounters other problems translating,
 // an error is returned.
-func (c Config) ToIgn3_4(options common.TranslateOptions) (types.Config, report.Report, error) {
-	cfg, r, err := cutil.Translate(c, "ToIgn3_4Unvalidated", options)
+func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_2Unvalidated", options)
 	return cfg.(types.Config), r, err
 }
 
@@ -135,7 +135,7 @@ func (c Config) ToIgn3_4(options common.TranslateOptions) (types.Config, report.
 // translating, an error is returned.
 func ToConfigBytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
 	if options.Raw {
-		return cutil.TranslateBytes(input, &Config{}, "ToIgn3_4", options)
+		return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
 	} else {
 		return cutil.TranslateBytesYAML(input, &Config{}, "ToMachineConfig4_10", options)
 	}
@@ -200,15 +200,8 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
 	// Error classes for the purposes of this function:
 	//
-	// UNPARSABLE - Cannot be rendered into a config by the MCC.  If
-	// present in MC, MCC will mark the pool degraded.  We reject these.
-	//
 	// FORBIDDEN - Not supported by the MCD.  If present in MC, MCD will
 	// mark the node degraded.  We reject these.
-	//
-	// REDUNDANT - Feature is also provided by a MachineConfig-specific
-	// field with different semantics.  To reduce confusion, disable
-	// this implementation.
 	//
 	// IMMUTABLE - Permitted in MC, passed through to Ignition, but not
 	// supported by the MCD.  MCD will mark the node degraded if the
@@ -222,12 +215,6 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 	// supported fields.  We reject these.
 
 	var r report.Report
-	for i, fs := range mc.Spec.Config.Storage.Filesystems {
-		if fs.Format != nil && *fs.Format == "none" {
-			// UNPARSABLE
-			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrFilesystemNoneSupport)
-		}
-	}
 	for i := range mc.Spec.Config.Storage.Directories {
 		// IMMUTABLE
 		r.AddOnError(path.New("json", "spec", "config", "storage", "directories", i), common.ErrDirectorySupport)
@@ -280,14 +267,6 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			// TRIPWIRE
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
-	}
-	for i := range mc.Spec.Config.KernelArguments.ShouldExist {
-		// UNPARSABLE, REDUNDANT
-		r.AddOnError(path.New("json", "spec", "config", "kernelArguments", "shouldExist", i), common.ErrKernelArgumentSupport)
-	}
-	for i := range mc.Spec.Config.KernelArguments.ShouldNotExist {
-		// UNPARSABLE, REDUNDANT
-		r.AddOnError(path.New("json", "spec", "config", "kernelArguments", "shouldNotExist", i), common.ErrKernelArgumentSupport)
 	}
 	return cutil.TranslateReportPaths(r, ts)
 }

--- a/config/openshift/v4_10/translate_test.go
+++ b/config/openshift/v4_10/translate_test.go
@@ -18,14 +18,14 @@ import (
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
-	base "github.com/coreos/butane/base/v0_5_exp"
+	base "github.com/coreos/butane/base/v0_3"
 	"github.com/coreos/butane/config/common"
-	fcos "github.com/coreos/butane/config/fcos/v1_5_exp"
+	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_10/result"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +50,7 @@ func TestElidedFieldWarning(t *testing.T) {
 	expected.AddOnWarn(path.New("yaml", "openshift", "fips"), common.ErrFieldElided)
 	expected.AddOnWarn(path.New("yaml", "openshift", "kernel_type"), common.ErrFieldElided)
 
-	_, _, r := in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+	_, _, r := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
 	assert.Equal(t, expected, r, "report mismatch")
 }
 
@@ -82,7 +82,7 @@ func TestTranslateConfig(t *testing.T) {
 				Spec: result.Spec{
 					Config: types.Config{
 						Ignition: types.Ignition{
-							Version: "3.4.0-experimental",
+							Version: "3.2.0",
 						},
 					},
 				},
@@ -157,7 +157,7 @@ func TestTranslateConfig(t *testing.T) {
 				Spec: result.Spec{
 					Config: types.Config{
 						Ignition: types.Ignition{
-							Version: "3.4.0-experimental",
+							Version: "3.2.0",
 						},
 						Storage: types.Storage{
 							Filesystems: []types.Filesystem{
@@ -175,7 +175,7 @@ func TestTranslateConfig(t *testing.T) {
 									Label:      util.StrToPtr("luks-root"),
 									WipeVolume: util.BoolToPtr(true),
 									Options:    []types.LuksOption{fipsCipherOption, fipsCipherArgument},
-									Clevis: types.Clevis{
+									Clevis: &types.Clevis{
 										Tpm2: util.BoolToPtr(true),
 									},
 								},
@@ -390,10 +390,6 @@ func TestValidateSupport(t *testing.T) {
 									Device: "/dev/vda4",
 									Format: util.StrToPtr("btrfs"),
 								},
-								{
-									Device: "/dev/vda5",
-									Format: util.StrToPtr("none"),
-								},
 							},
 							Directories: []base.Directory{
 								{
@@ -403,7 +399,7 @@ func TestValidateSupport(t *testing.T) {
 							Links: []base.Link{
 								{
 									Path:   "/l",
-									Target: util.StrToPtr("/t"),
+									Target: "/t",
 								},
 							},
 						},
@@ -437,20 +433,11 @@ func TestValidateSupport(t *testing.T) {
 								},
 							},
 						},
-						KernelArguments: base.KernelArguments{
-							ShouldExist: []base.KernelArgument{
-								"foo",
-							},
-							ShouldNotExist: []base.KernelArgument{
-								"bar",
-							},
-						},
 					},
 				},
 			},
 			[]entry{
 				{report.Error, common.ErrBtrfsSupport, path.New("yaml", "storage", "filesystems", 0, "format")},
-				{report.Error, common.ErrFilesystemNoneSupport, path.New("yaml", "storage", "filesystems", 1, "format")},
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
 				{report.Error, common.ErrFileSchemeSupport, path.New("yaml", "storage", "files", 2, "contents", "source")},
@@ -469,8 +456,6 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "system")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "uid")},
 				{report.Error, common.ErrUserNameSupport, path.New("yaml", "passwd", "users", 1)},
-				{report.Error, common.ErrKernelArgumentSupport, path.New("yaml", "kernel_arguments", "should_exist", 0)},
-				{report.Error, common.ErrKernelArgumentSupport, path.New("yaml", "kernel_arguments", "should_not_exist", 0)},
 			},
 		},
 	}

--- a/docs/config-openshift-v4_10.md
+++ b/docs/config-openshift-v4_10.md
@@ -9,7 +9,7 @@ nav_order: 96
 The OpenShift configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `openshift` for this specification.
-* **version** (string): the semantic version of the spec for this document. This document is for version `4.10.0` and generates Ignition configs with version `3.4.0-experimental`.
+* **version** (string): the semantic version of the spec for this document. This document is for version `4.10.0` and generates Ignition configs with version `3.2.0`.
 * **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
   * **name** (string): a unique [name][k8s-names] for this MachineConfig resource.
   * **labels** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource. `machineconfiguration.openshift.io/role` is required.

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -55,6 +55,6 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `fcos`         | 1.5.0-experimental  | 3.4.0-experimental |
 | `openshift`    | 4.8.0               | 3.2.0              |
 | `openshift`    | 4.9.0               | 3.2.0              |
-| `openshift`    | 4.10.0              | 3.4.0-experimental |
+| `openshift`    | 4.10.0              | 3.2.0              |
 | `openshift`    | 4.11.0-experimental | 3.4.0-experimental |
 | `rhcos`        | 0.1.0               | 3.2.0              |


### PR DESCRIPTION
The MCO doesn't support 3.3.0 yet, so we need to roll back `openshift` 4.10.0 to `fcos` 1.3.0 and base 0.3.  Validation was already rejecting the new fields in 3.3.0, so there are no docs changes to revert.

See also #269.