### PR TITLE
backport #279 to fcos < 1.3

### DIFF
--- a/config/fcos/v1_0/translate.go
+++ b/config/fcos/v1_0/translate.go
@@ -17,10 +17,39 @@ package v1_0
 import (
 	"github.com/coreos/butane/config/common"
 	cutil "github.com/coreos/butane/config/util"
+	"github.com/coreos/butane/translate"
 
+	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
+
+// ToIgn3_0Unvalidated translates the config to an Ignition config. It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_0Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	ret, ts, r := c.Config.ToIgn3_0Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
+
+	for i, disk := range ret.Storage.Disks {
+		// Don't warn if wipeTable is set, matching later spec versions
+		if !util.IsTrue(disk.WipeTable) {
+			for j, partition := range disk.Partitions {
+				// check for reserved partlabels
+				if partition.Label != nil {
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+			}
+		}
+	}
+	return ret, ts, r
+}
 
 // ToIgn3_0 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If

--- a/config/fcos/v1_0/translate_test.go
+++ b/config/fcos/v1_0/translate_test.go
@@ -1,0 +1,154 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_0
+
+import (
+	"fmt"
+	"testing"
+
+	baseutil "github.com/coreos/butane/base/util"
+	base "github.com/coreos/butane/base/v0_1"
+	"github.com/coreos/butane/config/common"
+	"github.com/coreos/butane/translate"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTranslateConfig tests translating the Butane config.
+func TestTranslateConfig(t *testing.T) {
+	tests := []struct {
+		in         Config
+		out        types.Config
+		exceptions []translate.Translation
+		report     report.Report
+	}{
+		// empty config
+		{
+			Config{},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.0.0",
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+			},
+			report.Report{},
+		},
+		// partition number for the `root` label is incorrect
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										SizeMiB: util.IntToPtr(12000),
+									},
+									{
+										Label:   util.StrToPtr("var-home"),
+										SizeMiB: util.IntToPtr(10240),
+									},
+								},
+							},
+						},
+						Filesystems: []base.Filesystem{
+							{
+								Device:         "/dev/disk/by-partlabel/var-home",
+								Format:         util.StrToPtr("xfs"),
+								Path:           util.StrToPtr("/var/home"),
+								Label:          util.StrToPtr("var-home"),
+								WipeFilesystem: util.BoolToPtr(false),
+							},
+						},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.0.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:   util.StrToPtr("root"),
+									SizeMiB: util.IntToPtr(12000),
+								},
+								{
+									Label:   util.StrToPtr("var-home"),
+									SizeMiB: util.IntToPtr(10240),
+								},
+							},
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/disk/by-partlabel/var-home",
+							Format:         util.StrToPtr("xfs"),
+							Path:           util.StrToPtr("/var/home"),
+							Label:          util.StrToPtr("var-home"),
+							WipeFilesystem: util.BoolToPtr(false),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "label"), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
+				{path.New("yaml", "storage", "disks", 0), path.New("json", "storage", "disks", 0)},
+				{path.New("yaml", "storage", "filesystems", 0, "device"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "storage", "filesystems", 0, "format"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "storage", "filesystems", 0, "path"), path.New("json", "storage", "filesystems", 0, "path")},
+				{path.New("yaml", "storage", "filesystems", 0, "label"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "storage", "filesystems", 0, "wipe_filesystem"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "storage", "filesystems", 0), path.New("json", "storage", "filesystems", 0)},
+				{path.New("yaml", "storage", "filesystems"), path.New("json", "storage", "filesystems")},
+				{path.New("yaml", "storage"), path.New("json", "storage")},
+			},
+			report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrWrongPartitionNumber.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r, "report mismatch")
+			baseutil.VerifyTranslations(t, translations, test.exceptions)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
+	}
+}

--- a/config/fcos/v1_1/translate_test.go
+++ b/config/fcos/v1_1/translate_test.go
@@ -1,0 +1,154 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1
+
+import (
+	"fmt"
+	"testing"
+
+	baseutil "github.com/coreos/butane/base/util"
+	base "github.com/coreos/butane/base/v0_2"
+	"github.com/coreos/butane/config/common"
+	"github.com/coreos/butane/translate"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_1/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTranslateConfig tests translating the Butane config.
+func TestTranslateConfig(t *testing.T) {
+	tests := []struct {
+		in         Config
+		out        types.Config
+		exceptions []translate.Translation
+		report     report.Report
+	}{
+		// empty config
+		{
+			Config{},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.1.0",
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+			},
+			report.Report{},
+		},
+		// partition number for the `root` label is incorrect
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										SizeMiB: util.IntToPtr(12000),
+									},
+									{
+										Label:   util.StrToPtr("var-home"),
+										SizeMiB: util.IntToPtr(10240),
+									},
+								},
+							},
+						},
+						Filesystems: []base.Filesystem{
+							{
+								Device:         "/dev/disk/by-partlabel/var-home",
+								Format:         util.StrToPtr("xfs"),
+								Path:           util.StrToPtr("/var/home"),
+								Label:          util.StrToPtr("var-home"),
+								WipeFilesystem: util.BoolToPtr(false),
+							},
+						},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.1.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:   util.StrToPtr("root"),
+									SizeMiB: util.IntToPtr(12000),
+								},
+								{
+									Label:   util.StrToPtr("var-home"),
+									SizeMiB: util.IntToPtr(10240),
+								},
+							},
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/disk/by-partlabel/var-home",
+							Format:         util.StrToPtr("xfs"),
+							Path:           util.StrToPtr("/var/home"),
+							Label:          util.StrToPtr("var-home"),
+							WipeFilesystem: util.BoolToPtr(false),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "label"), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
+				{path.New("yaml", "storage", "disks", 0), path.New("json", "storage", "disks", 0)},
+				{path.New("yaml", "storage", "filesystems", 0, "device"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "storage", "filesystems", 0, "format"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "storage", "filesystems", 0, "path"), path.New("json", "storage", "filesystems", 0, "path")},
+				{path.New("yaml", "storage", "filesystems", 0, "label"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "storage", "filesystems", 0, "wipe_filesystem"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "storage", "filesystems", 0), path.New("json", "storage", "filesystems", 0)},
+				{path.New("yaml", "storage", "filesystems"), path.New("json", "storage", "filesystems")},
+				{path.New("yaml", "storage"), path.New("json", "storage")},
+			},
+			report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrWrongPartitionNumber.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r, "report mismatch")
+			baseutil.VerifyTranslations(t, translations, test.exceptions)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
+	}
+}

--- a/config/fcos/v1_2/translate.go
+++ b/config/fcos/v1_2/translate.go
@@ -17,10 +17,39 @@ package v1_2
 import (
 	"github.com/coreos/butane/config/common"
 	cutil "github.com/coreos/butane/config/util"
+	"github.com/coreos/butane/translate"
 
+	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
+
+// ToIgn3_2Unvalidated translates the config to an Ignition config. It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	ret, ts, r := c.Config.ToIgn3_2Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
+
+	for i, disk := range ret.Storage.Disks {
+		// Don't warn if wipeTable is set, matching later spec versions
+		if !util.IsTrue(disk.WipeTable) {
+			for j, partition := range disk.Partitions {
+				// check for reserved partlabels
+				if partition.Label != nil {
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+			}
+		}
+	}
+	return ret, ts, r
+}
 
 // ToIgn3_2 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If

--- a/config/fcos/v1_2/translate_test.go
+++ b/config/fcos/v1_2/translate_test.go
@@ -1,0 +1,157 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_2
+
+import (
+	"fmt"
+	"testing"
+
+	baseutil "github.com/coreos/butane/base/util"
+	base "github.com/coreos/butane/base/v0_3"
+	"github.com/coreos/butane/config/common"
+	"github.com/coreos/butane/translate"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTranslateConfig tests translating the Butane config.
+func TestTranslateConfig(t *testing.T) {
+	tests := []struct {
+		in         Config
+		out        types.Config
+		exceptions []translate.Translation
+		report     report.Report
+	}{
+		// empty config
+		{
+			Config{},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+			},
+			report.Report{},
+		},
+		// partition number for the `root` label is incorrect
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										SizeMiB: util.IntToPtr(12000),
+										Resize:  util.BoolToPtr(true),
+									},
+									{
+										Label:   util.StrToPtr("var-home"),
+										SizeMiB: util.IntToPtr(10240),
+									},
+								},
+							},
+						},
+						Filesystems: []base.Filesystem{
+							{
+								Device:         "/dev/disk/by-partlabel/var-home",
+								Format:         util.StrToPtr("xfs"),
+								Path:           util.StrToPtr("/var/home"),
+								Label:          util.StrToPtr("var-home"),
+								WipeFilesystem: util.BoolToPtr(false),
+							},
+						},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:   util.StrToPtr("root"),
+									SizeMiB: util.IntToPtr(12000),
+									Resize:  util.BoolToPtr(true),
+								},
+								{
+									Label:   util.StrToPtr("var-home"),
+									SizeMiB: util.IntToPtr(10240),
+								},
+							},
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/disk/by-partlabel/var-home",
+							Format:         util.StrToPtr("xfs"),
+							Path:           util.StrToPtr("/var/home"),
+							Label:          util.StrToPtr("var-home"),
+							WipeFilesystem: util.BoolToPtr(false),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "version"), path.New("json", "ignition", "version")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "resize"), path.New("json", "storage", "disks", 0, "partitions", 0, "resize")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "label"), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 1, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0), path.New("json", "storage", "disks", 0, "partitions", 0)},
+				{path.New("yaml", "storage", "disks", 0), path.New("json", "storage", "disks", 0)},
+				{path.New("yaml", "storage", "filesystems", 0, "device"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "storage", "filesystems", 0, "format"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "storage", "filesystems", 0, "path"), path.New("json", "storage", "filesystems", 0, "path")},
+				{path.New("yaml", "storage", "filesystems", 0, "label"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "storage", "filesystems", 0, "wipe_filesystem"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "storage", "filesystems", 0), path.New("json", "storage", "filesystems", 0)},
+				{path.New("yaml", "storage", "filesystems"), path.New("json", "storage", "filesystems")},
+				{path.New("yaml", "storage"), path.New("json", "storage")},
+			},
+			report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrWrongPartitionNumber.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r, "report mismatch")
+			baseutil.VerifyTranslations(t, translations, test.exceptions)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
+	}
+}


### PR DESCRIPTION
Ideally, this change should have been addressed for `fcos v1_0, v1_1, and v1_2` in #279, however, it's missed somehow.