### PR TITLE
Cleanup

### DIFF
--- a/base/util/file_test.go
+++ b/base/util/file_test.go
@@ -101,12 +101,15 @@ var (
 func TestCheckForDecimalMode(t *testing.T) {
 	// test decimal to octal conversion
 	for i := -1; i < 10001; i++ {
-		iStr := fmt.Sprintf("%d", i)
-		result, ok := decimalModeToOctal(i)
-		assert.Equal(t, i >= 0 && i <= 7777 && !strings.ContainsAny(iStr, "89"), ok, "converting %d to octal returned incorrect ok", i)
-		if ok {
-			assert.Equal(t, iStr, fmt.Sprintf("%o", result), "converting %d to octal failed", i)
-		}
+		t.Run(fmt.Sprintf("mode %d", i), func(t *testing.T) {
+			iStr := fmt.Sprintf("%d", i)
+			result, ok := decimalModeToOctal(i)
+
+			assert.Equal(t, i >= 0 && i <= 7777 && !strings.ContainsAny(iStr, "89"), ok, "converting to octal returned incorrect ok")
+			if ok {
+				assert.Equal(t, iStr, fmt.Sprintf("%o", result), "converting to octal failed")
+			}
+		})
 	}
 
 	// check the checker against a hardcoded list

--- a/base/util/merge.go
+++ b/base/util/merge.go
@@ -62,7 +62,7 @@ func MergeTranslatedConfigs(parent interface{}, parentTranslations translate.Tra
 			// probably a desugared config whose source is
 			// textually unrelated to the result config.
 			//
-			// Currently Ignition always reports parent before
+			// Currently, Ignition always reports parent before
 			// child, but that isn't necessarily contractual, so
 			// we don't assume it.  Here, we've found the second
 			// entry and it's not from the child; skip it.

--- a/base/util/merge_test.go
+++ b/base/util/merge_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/translate"
@@ -141,9 +142,11 @@ func TestMergeTranslatedConfigs(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		c, ts := MergeTranslatedConfigs(test.parent, test.parentTranslations, test.child, test.childTranslations)
-		assert.Equal(t, test.merged, c, "#%d: bad config", i)
-		assert.Equal(t, test.mergedTranslations, ts, "#%d: bad translations", i)
+		t.Run(fmt.Sprintf("merge %d", i), func(t *testing.T) {
+			c, ts := MergeTranslatedConfigs(test.parent, test.parentTranslations, test.child, test.childTranslations)
+			assert.Equal(t, test.merged, c, "bad config")
+			assert.Equal(t, test.mergedTranslations, ts, "bad translations")
+		})
 	}
 }
 

--- a/base/v0_1/translate_test.go
+++ b/base/v0_1/translate_test.go
@@ -250,7 +250,7 @@ func TestTranslateLink(t *testing.T) {
 }
 
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
-// It ensure that the version is set as well.
+// It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {
 	tests := []struct {
 		in  Ignition
@@ -276,7 +276,7 @@ func TestTranslateIgnition(t *testing.T) {
 }
 
 // TestToIgn3_0 tests the config.ToIgn3_0 function ensuring it will generate a valid config even when empty. Not much else is
-// tested since it uses the Ignition translation code which has it's own set of tests.
+// tested since it uses the Ignition translation code which has its own set of tests.
 func TestToIgn3_0(t *testing.T) {
 	tests := []struct {
 		in  Config

--- a/base/v0_1/translate_test.go
+++ b/base/v0_1/translate_test.go
@@ -15,6 +15,7 @@
 package v0_1
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -131,11 +132,13 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateFile(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateFile(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -186,10 +189,12 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -242,10 +247,12 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -264,14 +271,16 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// DebugVerifyCoverage wants to see a translation for $.version but
-		// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
-		// that since it has access to the Butane config version
-		translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// DebugVerifyCoverage wants to see a translation for $.version but
+			// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
+			// that since it has access to the Butane config version
+			translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -292,9 +301,11 @@ func TestToIgn3_0(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/base/v0_1/validate_test.go
+++ b/base/v0_1/validate_test.go
@@ -15,6 +15,7 @@
 package v0_1
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -68,16 +69,18 @@ func TestValidateFileContents(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		// hardcode inline for now since that's the only place errors occur. Move into the
-		// test struct once there's more than one place
-		expected.AddOnError(path.New("yaml", "inline"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			// hardcode inline for now since that's the only place errors occur. Move into the
+			// test struct once there's more than one place
+			expected.AddOnError(path.New("yaml", "inline"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
-func TestValidateMode(t *testing.T) {
+func TestValidateFileMode(t *testing.T) {
 	fileTests := []struct {
 		in  File
 		out error
@@ -101,12 +104,16 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range fileTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
+}
 
+func TestValidateDirMode(t *testing.T) {
 	dirTests := []struct {
 		in  Directory
 		out error
@@ -130,9 +137,11 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range dirTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -227,12 +227,12 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 			destBaseDir = *tree.Path
 		}
 
-		walkTree(yamlPath, tree, &ts, &r, t, srcBaseDir, destBaseDir, options)
+		walkTree(yamlPath, &ts, &r, t, srcBaseDir, destBaseDir, options)
 	}
 	return ts, r
 }
 
-func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
+func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
 	// The strategy for errors within WalkFunc is to add an error to
 	// the report and return nil, so walking continues but translation
 	// will fail afterward.

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -1237,19 +1237,19 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for path, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, mode := range test.dirFiles {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
 			}
-			if err := ioutil.WriteFile(absPath, []byte(path), mode); err != nil {
+			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
 				t.Error(err)
 				return
 			}
 		}
-		for path, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, target := range test.dirLinks {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
@@ -1259,8 +1259,8 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for _, path := range test.dirSockets {
-			absPath := filepath.Join(filesDir, path)
+		for _, testPath := range test.dirSockets {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -1316,7 +1316,7 @@ func TestTranslateTree(t *testing.T) {
 }
 
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
-// It ensure that the version is set as well.
+// It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {
 	tests := []struct {
 		in  Ignition
@@ -1409,7 +1409,7 @@ func TestTranslateIgnition(t *testing.T) {
 }
 
 // TestToIgn3_1 tests the config.ToIgn3_1 function ensuring it will generate a valid config even when empty. Not much else is
-// tested since it uses the Ignition translation code which has it's own set of tests.
+// tested since it uses the Ignition translation code which has its own set of tests.
 func TestToIgn3_1(t *testing.T) {
 	tests := []struct {
 		in  Config

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -15,6 +15,7 @@
 package v0_2
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -454,11 +455,13 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateFile(test.in, test.options)
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, test.report, r.String(), "#%d: bad report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateFile(test.in, test.options)
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r.String(), "bad report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -509,10 +512,12 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -565,10 +570,12 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -610,28 +617,30 @@ func TestTranslateFilesystem(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// Filesystem doesn't have a custom translator, so embed in a
-		// complete config
-		in := Config{
-			Storage: Storage{
-				Filesystems: []Filesystem{test.in},
-			},
-		}
-		expected := []types.Filesystem{test.out}
-		actual, translations, r := in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expected, actual.Storage.Filesystems, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// FIXME: Zero values are pruned from merge transcripts and
-		// TranslationSets to make them more compact in debug output
-		// and tests.  As a result, if the user specifies an empty
-		// struct in a list, the translation coverage will be
-		// incomplete and the report entry marker will end up
-		// pointing to the base of the list, or to a parent if the
-		// struct is the only entry in the list.  Skip the coverage
-		// test for this case.
-		if !reflect.ValueOf(test.out).IsZero() {
-			assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
-		}
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			// Filesystem doesn't have a custom translator, so embed in a
+			// complete config
+			in := Config{
+				Storage: Storage{
+					Filesystems: []Filesystem{test.in},
+				},
+			}
+			expected := []types.Filesystem{test.out}
+			actual, translations, r := in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// FIXME: Zero values are pruned from merge transcripts and
+			// TranslationSets to make them more compact in debug output
+			// and tests.  As a result, if the user specifies an empty
+			// struct in a list, the translation coverage will be
+			// incomplete and the report entry marker will end up
+			// pointing to the base of the list, or to a parent if the
+			// struct is the only entry in the list.  Skip the coverage
+			// test for this case.
+			if !reflect.ValueOf(test.out).IsZero() {
+				assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+			}
+		})
 	}
 }
 
@@ -801,10 +810,12 @@ RequiredBy=local-fs.target`),
 	}
 
 	for i, test := range tests {
-		out, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, out, "#%d: bad output", i)
-		assert.Equal(t, report.Report{}, r, "#%d: expected empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(out), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			out, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, out, "bad output")
+			assert.Equal(t, report.Report{}, r, "expected empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1225,83 +1236,85 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir := t.TempDir()
-		for testPath, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(absPath, 0755); err != nil {
-				t.Error(err)
-				return
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			filesDir := t.TempDir()
+			for testPath, mode := range test.dirDirs {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(absPath, 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Chmod(absPath, mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := os.Chmod(absPath, mode); err != nil {
-				t.Error(err)
-				return
+			for testPath, mode := range test.dirFiles {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-		}
-		for testPath, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
+			for testPath, target := range test.dirLinks {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Symlink(target, absPath); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
-				t.Error(err)
-				return
+			for _, testPath := range test.dirSockets {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				listener, err := net.ListenUnix("unix", &net.UnixAddr{
+					Name: absPath,
+					Net:  "unix",
+				})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer listener.Close()
 			}
-		}
-		for testPath, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			if err := os.Symlink(target, absPath); err != nil {
-				t.Error(err)
-				return
-			}
-		}
-		for _, testPath := range test.dirSockets {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			listener, err := net.ListenUnix("unix", &net.UnixAddr{
-				Name: absPath,
-				Net:  "unix",
-			})
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			defer listener.Close()
-		}
 
-		config := Config{
-			Storage: Storage{
-				Files:       test.inFiles,
-				Directories: test.inDirs,
-				Links:       test.inLinks,
-				Trees:       test.inTrees,
-			},
-		}
-		options := common.TranslateOptions{
-			FilesDir: filesDir,
-		}
-		if test.options != nil {
-			options = *test.options
-		}
-		actual, translations, r := config.ToIgn3_1Unvalidated(options)
+			config := Config{
+				Storage: Storage{
+					Files:       test.inFiles,
+					Directories: test.inDirs,
+					Links:       test.inLinks,
+					Trees:       test.inTrees,
+				},
+			}
+			options := common.TranslateOptions{
+				FilesDir: filesDir,
+			}
+			if test.options != nil {
+				options = *test.options
+			}
+			actual, translations, r := config.ToIgn3_1Unvalidated(options)
 
-		expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
-		assert.Equal(t, expectedReport, r.String(), "#%d: bad report", i)
-		if expectedReport != "" {
-			continue
-		}
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
+			assert.Equal(t, expectedReport, r.String(), "bad report")
+			if expectedReport != "" {
+				return
+			}
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 
-		assert.Equal(t, test.outFiles, actual.Storage.Files, "#%d: files mismatch", i)
-		assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "#%d: directories mismatch", i)
-		assert.Equal(t, test.outLinks, actual.Storage.Links, "#%d: links mismatch", i)
+			assert.Equal(t, test.outFiles, actual.Storage.Files, "files mismatch")
+			assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "directories mismatch")
+			assert.Equal(t, test.outLinks, actual.Storage.Links, "links mismatch")
+		})
 	}
 }
 
@@ -1387,14 +1400,16 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// DebugVerifyCoverage wants to see a translation for $.version but
-		// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
-		// that since it has access to the Butane config version
-		translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// DebugVerifyCoverage wants to see a translation for $.version but
+			// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
+			// that since it has access to the Butane config version
+			translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1415,9 +1430,11 @@ func TestToIgn3_1(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -43,12 +43,7 @@ func TestTranslateFile(t *testing.T) {
 	random := "\xc0\x9cl\x01\x89i\xa5\xbfW\xe4\x1b\xf4J_\xb79P\xa3#\xa7"
 	random_b64 := "data:;base64,wJxsAYlppb9X5Bv0Sl+3OVCjI6c="
 
-	filesDir, err := ioutil.TempDir("", "translate-test-")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer os.RemoveAll(filesDir)
+	filesDir := t.TempDir()
 	fileContents := map[string]string{
 		"file-1": "file contents\n",
 		"file-2": zzz,
@@ -1230,14 +1225,9 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir, err := ioutil.TempDir("", "translate-test-")
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		defer os.RemoveAll(filesDir)
-		for path, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, path)
+		filesDir := t.TempDir()
+		for testPath, mode := range test.dirDirs {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(absPath, 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_2/validate_test.go
+++ b/base/v0_2/validate_test.go
@@ -15,6 +15,7 @@
 package v0_2
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -127,10 +128,12 @@ func TestValidateResource(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -146,14 +149,16 @@ func TestValidateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(path.New("yaml"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(path.New("yaml"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
-func TestValidateMode(t *testing.T) {
+func TestValidateFileMode(t *testing.T) {
 	fileTests := []struct {
 		in  File
 		out error
@@ -177,12 +182,16 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range fileTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
+}
 
+func TestValidateDirMode(t *testing.T) {
 	dirTests := []struct {
 		in  Directory
 		out error
@@ -206,9 +215,12 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range dirTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
+
 }

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -238,12 +238,12 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 			destBaseDir = *tree.Path
 		}
 
-		walkTree(yamlPath, tree, &ts, &r, t, srcBaseDir, destBaseDir, options)
+		walkTree(yamlPath, &ts, &r, t, srcBaseDir, destBaseDir, options)
 	}
 	return ts, r
 }
 
-func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
+func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
 	// The strategy for errors within WalkFunc is to add an error to
 	// the report and return nil, so walking continues but translation
 	// will fail afterward.

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -15,6 +15,7 @@
 package v0_3
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -454,11 +455,13 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateFile(test.in, test.options)
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, test.report, r.String(), "#%d: bad report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateFile(test.in, test.options)
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r.String(), "bad report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -509,10 +512,12 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -565,10 +570,12 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -610,28 +617,30 @@ func TestTranslateFilesystem(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// Filesystem doesn't have a custom translator, so embed in a
-		// complete config
-		in := Config{
-			Storage: Storage{
-				Filesystems: []Filesystem{test.in},
-			},
-		}
-		expected := []types.Filesystem{test.out}
-		actual, translations, r := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expected, actual.Storage.Filesystems, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// FIXME: Zero values are pruned from merge transcripts and
-		// TranslationSets to make them more compact in debug output
-		// and tests.  As a result, if the user specifies an empty
-		// struct in a list, the translation coverage will be
-		// incomplete and the report entry marker will end up
-		// pointing to the base of the list, or to a parent if the
-		// struct is the only entry in the list.  Skip the coverage
-		// test for this case.
-		if !reflect.ValueOf(test.out).IsZero() {
-			assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
-		}
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			// Filesystem doesn't have a custom translator, so embed in a
+			// complete config
+			in := Config{
+				Storage: Storage{
+					Filesystems: []Filesystem{test.in},
+				},
+			}
+			expected := []types.Filesystem{test.out}
+			actual, translations, r := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// FIXME: Zero values are pruned from merge transcripts and
+			// TranslationSets to make them more compact in debug output
+			// and tests.  As a result, if the user specifies an empty
+			// struct in a list, the translation coverage will be
+			// incomplete and the report entry marker will end up
+			// pointing to the base of the list, or to a parent if the
+			// struct is the only entry in the list.  Skip the coverage
+			// test for this case.
+			if !reflect.ValueOf(test.out).IsZero() {
+				assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+			}
+		})
 	}
 }
 
@@ -881,10 +890,12 @@ RequiredBy=local-fs.target`),
 	}
 
 	for i, test := range tests {
-		out, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, out, "#%d: bad output", i)
-		assert.Equal(t, report.Report{}, r, "#%d: expected empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(out), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			out, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, out, "bad output")
+			assert.Equal(t, report.Report{}, r, "expected empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1305,83 +1316,85 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir := t.TempDir()
-		for testPath, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(absPath, 0755); err != nil {
-				t.Error(err)
-				return
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			filesDir := t.TempDir()
+			for testPath, mode := range test.dirDirs {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(absPath, 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Chmod(absPath, mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := os.Chmod(absPath, mode); err != nil {
-				t.Error(err)
-				return
+			for testPath, mode := range test.dirFiles {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-		}
-		for testPath, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
+			for testPath, target := range test.dirLinks {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Symlink(target, absPath); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
-				t.Error(err)
-				return
+			for _, testPath := range test.dirSockets {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				listener, err := net.ListenUnix("unix", &net.UnixAddr{
+					Name: absPath,
+					Net:  "unix",
+				})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer listener.Close()
 			}
-		}
-		for testPath, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			if err := os.Symlink(target, absPath); err != nil {
-				t.Error(err)
-				return
-			}
-		}
-		for _, testPath := range test.dirSockets {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			listener, err := net.ListenUnix("unix", &net.UnixAddr{
-				Name: absPath,
-				Net:  "unix",
-			})
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			defer listener.Close()
-		}
 
-		config := Config{
-			Storage: Storage{
-				Files:       test.inFiles,
-				Directories: test.inDirs,
-				Links:       test.inLinks,
-				Trees:       test.inTrees,
-			},
-		}
-		options := common.TranslateOptions{
-			FilesDir: filesDir,
-		}
-		if test.options != nil {
-			options = *test.options
-		}
-		actual, translations, r := config.ToIgn3_2Unvalidated(options)
+			config := Config{
+				Storage: Storage{
+					Files:       test.inFiles,
+					Directories: test.inDirs,
+					Links:       test.inLinks,
+					Trees:       test.inTrees,
+				},
+			}
+			options := common.TranslateOptions{
+				FilesDir: filesDir,
+			}
+			if test.options != nil {
+				options = *test.options
+			}
+			actual, translations, r := config.ToIgn3_2Unvalidated(options)
 
-		expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
-		assert.Equal(t, expectedReport, r.String(), "#%d: bad report", i)
-		if expectedReport != "" {
-			continue
-		}
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
+			assert.Equal(t, expectedReport, r.String(), "bad report")
+			if expectedReport != "" {
+				return
+			}
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 
-		assert.Equal(t, test.outFiles, actual.Storage.Files, "#%d: files mismatch", i)
-		assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "#%d: directories mismatch", i)
-		assert.Equal(t, test.outLinks, actual.Storage.Links, "#%d: links mismatch", i)
+			assert.Equal(t, test.outFiles, actual.Storage.Files, "files mismatch")
+			assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "directories mismatch")
+			assert.Equal(t, test.outLinks, actual.Storage.Links, "links mismatch")
+		})
 	}
 }
 
@@ -1467,14 +1480,16 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// DebugVerifyCoverage wants to see a translation for $.version but
-		// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
-		// that since it has access to the Butane config version
-		translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// DebugVerifyCoverage wants to see a translation for $.version but
+			// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
+			// that since it has access to the Butane config version
+			translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1495,9 +1510,11 @@ func TestToIgn3_2(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -1396,7 +1396,7 @@ func TestTranslateTree(t *testing.T) {
 }
 
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
-// It ensure that the version is set as well.
+// It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {
 	tests := []struct {
 		in  Ignition
@@ -1489,7 +1489,7 @@ func TestTranslateIgnition(t *testing.T) {
 }
 
 // TestToIgn3_2 tests the config.ToIgn3_2 function ensuring it will generate a valid config even when empty. Not much else is
-// tested since it uses the Ignition translation code which has it's own set of tests.
+// tested since it uses the Ignition translation code which has its own set of tests.
 func TestToIgn3_2(t *testing.T) {
 	tests := []struct {
 		in  Config

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -43,12 +43,7 @@ func TestTranslateFile(t *testing.T) {
 	random := "\xc0\x9cl\x01\x89i\xa5\xbfW\xe4\x1b\xf4J_\xb79P\xa3#\xa7"
 	random_b64 := "data:;base64,wJxsAYlppb9X5Bv0Sl+3OVCjI6c="
 
-	filesDir, err := ioutil.TempDir("", "translate-test-")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer os.RemoveAll(filesDir)
+	filesDir := t.TempDir()
 	fileContents := map[string]string{
 		"file-1": "file contents\n",
 		"file-2": zzz,
@@ -1310,14 +1305,9 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir, err := ioutil.TempDir("", "translate-test-")
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		defer os.RemoveAll(filesDir)
-		for path, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, path)
+		filesDir := t.TempDir()
+		for testPath, mode := range test.dirDirs {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(absPath, 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -1317,19 +1317,19 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for path, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, mode := range test.dirFiles {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
 			}
-			if err := ioutil.WriteFile(absPath, []byte(path), mode); err != nil {
+			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
 				t.Error(err)
 				return
 			}
 		}
-		for path, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, target := range test.dirLinks {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
@@ -1339,8 +1339,8 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for _, path := range test.dirSockets {
-			absPath := filepath.Join(filesDir, path)
+		for _, testPath := range test.dirSockets {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_3/validate_test.go
+++ b/base/v0_3/validate_test.go
@@ -15,6 +15,7 @@
 package v0_3
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -127,10 +128,12 @@ func TestValidateResource(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -146,14 +149,16 @@ func TestValidateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(path.New("yaml"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(path.New("yaml"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
-func TestValidateMode(t *testing.T) {
+func TestValidateFileMode(t *testing.T) {
 	fileTests := []struct {
 		in  File
 		out error
@@ -177,12 +182,16 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range fileTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
+}
 
+func TestValidateDirMode(t *testing.T) {
 	dirTests := []struct {
 		in  Directory
 		out error
@@ -206,9 +215,11 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range dirTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }

--- a/base/v0_4/translate.go
+++ b/base/v0_4/translate.go
@@ -253,12 +253,12 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 			destBaseDir = *tree.Path
 		}
 
-		walkTree(yamlPath, tree, &ts, &r, t, srcBaseDir, destBaseDir, options)
+		walkTree(yamlPath, &ts, &r, t, srcBaseDir, destBaseDir, options)
 	}
 	return ts, r
 }
 
-func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
+func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
 	// The strategy for errors within WalkFunc is to add an error to
 	// the report and return nil, so walking continues but translation
 	// will fail afterward.

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -1402,19 +1402,19 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for path, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, mode := range test.dirFiles {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
 			}
-			if err := ioutil.WriteFile(absPath, []byte(path), mode); err != nil {
+			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
 				t.Error(err)
 				return
 			}
 		}
-		for path, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, target := range test.dirLinks {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
@@ -1424,8 +1424,8 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for _, path := range test.dirSockets {
-			absPath := filepath.Join(filesDir, path)
+		for _, testPath := range test.dirSockets {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -15,6 +15,7 @@
 package v0_4
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -454,11 +455,13 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateFile(test.in, test.options)
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, test.report, r.String(), "#%d: bad report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateFile(test.in, test.options)
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r.String(), "bad report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -509,10 +512,12 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -565,10 +570,12 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -610,28 +617,30 @@ func TestTranslateFilesystem(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// Filesystem doesn't have a custom translator, so embed in a
-		// complete config
-		in := Config{
-			Storage: Storage{
-				Filesystems: []Filesystem{test.in},
-			},
-		}
-		expected := []types.Filesystem{test.out}
-		actual, translations, r := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expected, actual.Storage.Filesystems, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// FIXME: Zero values are pruned from merge transcripts and
-		// TranslationSets to make them more compact in debug output
-		// and tests.  As a result, if the user specifies an empty
-		// struct in a list, the translation coverage will be
-		// incomplete and the report entry marker will end up
-		// pointing to the base of the list, or to a parent if the
-		// struct is the only entry in the list.  Skip the coverage
-		// test for this case.
-		if !reflect.ValueOf(test.out).IsZero() {
-			assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
-		}
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			// Filesystem doesn't have a custom translator, so embed in a
+			// complete config
+			in := Config{
+				Storage: Storage{
+					Filesystems: []Filesystem{test.in},
+				},
+			}
+			expected := []types.Filesystem{test.out}
+			actual, translations, r := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// FIXME: Zero values are pruned from merge transcripts and
+			// TranslationSets to make them more compact in debug output
+			// and tests.  As a result, if the user specifies an empty
+			// struct in a list, the translation coverage will be
+			// incomplete and the report entry marker will end up
+			// pointing to the base of the list, or to a parent if the
+			// struct is the only entry in the list.  Skip the coverage
+			// test for this case.
+			if !reflect.ValueOf(test.out).IsZero() {
+				assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+			}
+		})
 	}
 }
 
@@ -966,10 +975,12 @@ RequiredBy=swap.target`),
 	}
 
 	for i, test := range tests {
-		out, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, out, "#%d: bad output", i)
-		assert.Equal(t, report.Report{}, r, "#%d: expected empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(out), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			out, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, out, "bad output")
+			assert.Equal(t, report.Report{}, r, "expected empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1390,83 +1401,85 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir := t.TempDir()
-		for testPath, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(absPath, 0755); err != nil {
-				t.Error(err)
-				return
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			filesDir := t.TempDir()
+			for testPath, mode := range test.dirDirs {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(absPath, 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Chmod(absPath, mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := os.Chmod(absPath, mode); err != nil {
-				t.Error(err)
-				return
+			for testPath, mode := range test.dirFiles {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-		}
-		for testPath, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
+			for testPath, target := range test.dirLinks {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Symlink(target, absPath); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
-				t.Error(err)
-				return
+			for _, testPath := range test.dirSockets {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				listener, err := net.ListenUnix("unix", &net.UnixAddr{
+					Name: absPath,
+					Net:  "unix",
+				})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer listener.Close()
 			}
-		}
-		for testPath, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			if err := os.Symlink(target, absPath); err != nil {
-				t.Error(err)
-				return
-			}
-		}
-		for _, testPath := range test.dirSockets {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			listener, err := net.ListenUnix("unix", &net.UnixAddr{
-				Name: absPath,
-				Net:  "unix",
-			})
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			defer listener.Close()
-		}
 
-		config := Config{
-			Storage: Storage{
-				Files:       test.inFiles,
-				Directories: test.inDirs,
-				Links:       test.inLinks,
-				Trees:       test.inTrees,
-			},
-		}
-		options := common.TranslateOptions{
-			FilesDir: filesDir,
-		}
-		if test.options != nil {
-			options = *test.options
-		}
-		actual, translations, r := config.ToIgn3_3Unvalidated(options)
+			config := Config{
+				Storage: Storage{
+					Files:       test.inFiles,
+					Directories: test.inDirs,
+					Links:       test.inLinks,
+					Trees:       test.inTrees,
+				},
+			}
+			options := common.TranslateOptions{
+				FilesDir: filesDir,
+			}
+			if test.options != nil {
+				options = *test.options
+			}
+			actual, translations, r := config.ToIgn3_3Unvalidated(options)
 
-		expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
-		assert.Equal(t, expectedReport, r.String(), "#%d: bad report", i)
-		if expectedReport != "" {
-			continue
-		}
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
+			assert.Equal(t, expectedReport, r.String(), "bad report")
+			if expectedReport != "" {
+				return
+			}
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 
-		assert.Equal(t, test.outFiles, actual.Storage.Files, "#%d: files mismatch", i)
-		assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "#%d: directories mismatch", i)
-		assert.Equal(t, test.outLinks, actual.Storage.Links, "#%d: links mismatch", i)
+			assert.Equal(t, test.outFiles, actual.Storage.Files, "files mismatch")
+			assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "directories mismatch")
+			assert.Equal(t, test.outLinks, actual.Storage.Links, "links mismatch")
+		})
 	}
 }
 
@@ -1552,14 +1565,16 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// DebugVerifyCoverage wants to see a translation for $.version but
-		// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
-		// that since it has access to the Butane config version
-		translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// DebugVerifyCoverage wants to see a translation for $.version but
+			// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
+			// that since it has access to the Butane config version
+			translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1599,10 +1614,12 @@ func TestTranslateKernelArguments(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1623,9 +1640,11 @@ func TestToIgn3_3(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -1481,7 +1481,7 @@ func TestTranslateTree(t *testing.T) {
 }
 
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
-// It ensure that the version is set as well.
+// It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {
 	tests := []struct {
 		in  Ignition
@@ -1617,7 +1617,7 @@ func TestTranslateKernelArguments(t *testing.T) {
 }
 
 // TestToIgn3_3 tests the config.ToIgn3_3 function ensuring it will generate a valid config even when empty. Not much else is
-// tested since it uses the Ignition translation code which has it's own set of tests.
+// tested since it uses the Ignition translation code which has its own set of tests.
 func TestToIgn3_3(t *testing.T) {
 	tests := []struct {
 		in  Config

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -43,12 +43,7 @@ func TestTranslateFile(t *testing.T) {
 	random := "\xc0\x9cl\x01\x89i\xa5\xbfW\xe4\x1b\xf4J_\xb79P\xa3#\xa7"
 	random_b64 := "data:;base64,wJxsAYlppb9X5Bv0Sl+3OVCjI6c="
 
-	filesDir, err := ioutil.TempDir("", "translate-test-")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer os.RemoveAll(filesDir)
+	filesDir := t.TempDir()
 	fileContents := map[string]string{
 		"file-1": "file contents\n",
 		"file-2": zzz,
@@ -1395,14 +1390,9 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir, err := ioutil.TempDir("", "translate-test-")
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		defer os.RemoveAll(filesDir)
-		for path, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, path)
+		filesDir := t.TempDir()
+		for testPath, mode := range test.dirDirs {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(absPath, 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_4/validate_test.go
+++ b/base/v0_4/validate_test.go
@@ -15,6 +15,7 @@
 package v0_4
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -127,10 +128,12 @@ func TestValidateResource(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -146,14 +149,16 @@ func TestValidateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(path.New("yaml"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(path.New("yaml"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
-func TestValidateMode(t *testing.T) {
+func TestValidateFileMode(t *testing.T) {
 	fileTests := []struct {
 		in  File
 		out error
@@ -177,12 +182,16 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range fileTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
+}
 
+func TestValidateDirMode(t *testing.T) {
 	dirTests := []struct {
 		in  Directory
 		out error
@@ -206,10 +215,12 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range dirTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -270,9 +281,11 @@ func TestValidateFilesystem(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }

--- a/base/v0_5_exp/translate.go
+++ b/base/v0_5_exp/translate.go
@@ -253,12 +253,12 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 			destBaseDir = *tree.Path
 		}
 
-		walkTree(yamlPath, tree, &ts, &r, t, srcBaseDir, destBaseDir, options)
+		walkTree(yamlPath, &ts, &r, t, srcBaseDir, destBaseDir, options)
 	}
 	return ts, r
 }
 
-func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
+func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, srcBaseDir, destBaseDir string, options common.TranslateOptions) {
 	// The strategy for errors within WalkFunc is to add an error to
 	// the report and return nil, so walking continues but translation
 	// will fail afterward.

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -1402,19 +1402,19 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for path, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, mode := range test.dirFiles {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
 			}
-			if err := ioutil.WriteFile(absPath, []byte(path), mode); err != nil {
+			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
 				t.Error(err)
 				return
 			}
 		}
-		for path, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, path)
+		for testPath, target := range test.dirLinks {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return
@@ -1424,8 +1424,8 @@ func TestTranslateTree(t *testing.T) {
 				return
 			}
 		}
-		for _, path := range test.dirSockets {
-			absPath := filepath.Join(filesDir, path)
+		for _, testPath := range test.dirSockets {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -15,6 +15,7 @@
 package v0_5_exp
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -454,11 +455,13 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateFile(test.in, test.options)
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, test.report, r.String(), "#%d: bad report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateFile(test.in, test.options)
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r.String(), "bad report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -509,10 +512,12 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -565,10 +570,12 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -610,28 +617,30 @@ func TestTranslateFilesystem(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// Filesystem doesn't have a custom translator, so embed in a
-		// complete config
-		in := Config{
-			Storage: Storage{
-				Filesystems: []Filesystem{test.in},
-			},
-		}
-		expected := []types.Filesystem{test.out}
-		actual, translations, r := in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expected, actual.Storage.Filesystems, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// FIXME: Zero values are pruned from merge transcripts and
-		// TranslationSets to make them more compact in debug output
-		// and tests.  As a result, if the user specifies an empty
-		// struct in a list, the translation coverage will be
-		// incomplete and the report entry marker will end up
-		// pointing to the base of the list, or to a parent if the
-		// struct is the only entry in the list.  Skip the coverage
-		// test for this case.
-		if !reflect.ValueOf(test.out).IsZero() {
-			assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
-		}
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			// Filesystem doesn't have a custom translator, so embed in a
+			// complete config
+			in := Config{
+				Storage: Storage{
+					Filesystems: []Filesystem{test.in},
+				},
+			}
+			expected := []types.Filesystem{test.out}
+			actual, translations, r := in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// FIXME: Zero values are pruned from merge transcripts and
+			// TranslationSets to make them more compact in debug output
+			// and tests.  As a result, if the user specifies an empty
+			// struct in a list, the translation coverage will be
+			// incomplete and the report entry marker will end up
+			// pointing to the base of the list, or to a parent if the
+			// struct is the only entry in the list.  Skip the coverage
+			// test for this case.
+			if !reflect.ValueOf(test.out).IsZero() {
+				assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+			}
+		})
 	}
 }
 
@@ -966,10 +975,12 @@ RequiredBy=swap.target`),
 	}
 
 	for i, test := range tests {
-		out, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, out, "#%d: bad output", i)
-		assert.Equal(t, report.Report{}, r, "#%d: expected empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(out), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			out, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, out, "bad output")
+			assert.Equal(t, report.Report{}, r, "expected empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1390,83 +1401,85 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir := t.TempDir()
-		for testPath, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(absPath, 0755); err != nil {
-				t.Error(err)
-				return
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			filesDir := t.TempDir()
+			for testPath, mode := range test.dirDirs {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(absPath, 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Chmod(absPath, mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := os.Chmod(absPath, mode); err != nil {
-				t.Error(err)
-				return
+			for testPath, mode := range test.dirFiles {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-		}
-		for testPath, mode := range test.dirFiles {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
+			for testPath, target := range test.dirLinks {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := os.Symlink(target, absPath); err != nil {
+					t.Error(err)
+					return
+				}
 			}
-			if err := ioutil.WriteFile(absPath, []byte(testPath), mode); err != nil {
-				t.Error(err)
-				return
+			for _, testPath := range test.dirSockets {
+				absPath := filepath.Join(filesDir, testPath)
+				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+					t.Error(err)
+					return
+				}
+				listener, err := net.ListenUnix("unix", &net.UnixAddr{
+					Name: absPath,
+					Net:  "unix",
+				})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer listener.Close()
 			}
-		}
-		for testPath, target := range test.dirLinks {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			if err := os.Symlink(target, absPath); err != nil {
-				t.Error(err)
-				return
-			}
-		}
-		for _, testPath := range test.dirSockets {
-			absPath := filepath.Join(filesDir, testPath)
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				t.Error(err)
-				return
-			}
-			listener, err := net.ListenUnix("unix", &net.UnixAddr{
-				Name: absPath,
-				Net:  "unix",
-			})
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			defer listener.Close()
-		}
 
-		config := Config{
-			Storage: Storage{
-				Files:       test.inFiles,
-				Directories: test.inDirs,
-				Links:       test.inLinks,
-				Trees:       test.inTrees,
-			},
-		}
-		options := common.TranslateOptions{
-			FilesDir: filesDir,
-		}
-		if test.options != nil {
-			options = *test.options
-		}
-		actual, translations, r := config.ToIgn3_4Unvalidated(options)
+			config := Config{
+				Storage: Storage{
+					Files:       test.inFiles,
+					Directories: test.inDirs,
+					Links:       test.inLinks,
+					Trees:       test.inTrees,
+				},
+			}
+			options := common.TranslateOptions{
+				FilesDir: filesDir,
+			}
+			if test.options != nil {
+				options = *test.options
+			}
+			actual, translations, r := config.ToIgn3_4Unvalidated(options)
 
-		expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
-		assert.Equal(t, expectedReport, r.String(), "#%d: bad report", i)
-		if expectedReport != "" {
-			continue
-		}
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
+			assert.Equal(t, expectedReport, r.String(), "bad report")
+			if expectedReport != "" {
+				return
+			}
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 
-		assert.Equal(t, test.outFiles, actual.Storage.Files, "#%d: files mismatch", i)
-		assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "#%d: directories mismatch", i)
-		assert.Equal(t, test.outLinks, actual.Storage.Links, "#%d: links mismatch", i)
+			assert.Equal(t, test.outFiles, actual.Storage.Files, "files mismatch")
+			assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "directories mismatch")
+			assert.Equal(t, test.outLinks, actual.Storage.Links, "links mismatch")
+		})
 	}
 }
 
@@ -1552,14 +1565,16 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		// DebugVerifyCoverage wants to see a translation for $.version but
-		// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
-		// that since it has access to the Butane config version
-		translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			// DebugVerifyCoverage wants to see a translation for $.version but
+			// translateIgnition doesn't create one; ToIgn3_*Unvalidated handles
+			// that since it has access to the Butane config version
+			translations.AddTranslation(path.New("yaml", "bogus"), path.New("json", "version"))
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1599,10 +1614,12 @@ func TestTranslateKernelArguments(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -1623,9 +1640,11 @@ func TestToIgn3_4(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -1481,7 +1481,7 @@ func TestTranslateTree(t *testing.T) {
 }
 
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
-// It ensure that the version is set as well.
+// It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {
 	tests := []struct {
 		in  Ignition
@@ -1617,7 +1617,7 @@ func TestTranslateKernelArguments(t *testing.T) {
 }
 
 // TestToIgn3_4 tests the config.ToIgn3_4 function ensuring it will generate a valid config even when empty. Not much else is
-// tested since it uses the Ignition translation code which has it's own set of tests.
+// tested since it uses the Ignition translation code which has its own set of tests.
 func TestToIgn3_4(t *testing.T) {
 	tests := []struct {
 		in  Config

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -43,12 +43,7 @@ func TestTranslateFile(t *testing.T) {
 	random := "\xc0\x9cl\x01\x89i\xa5\xbfW\xe4\x1b\xf4J_\xb79P\xa3#\xa7"
 	random_b64 := "data:;base64,wJxsAYlppb9X5Bv0Sl+3OVCjI6c="
 
-	filesDir, err := ioutil.TempDir("", "translate-test-")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer os.RemoveAll(filesDir)
+	filesDir := t.TempDir()
 	fileContents := map[string]string{
 		"file-1": "file contents\n",
 		"file-2": zzz,
@@ -1395,14 +1390,9 @@ func TestTranslateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		filesDir, err := ioutil.TempDir("", "translate-test-")
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		defer os.RemoveAll(filesDir)
-		for path, mode := range test.dirDirs {
-			absPath := filepath.Join(filesDir, path)
+		filesDir := t.TempDir()
+		for testPath, mode := range test.dirDirs {
+			absPath := filepath.Join(filesDir, testPath)
 			if err := os.MkdirAll(absPath, 0755); err != nil {
 				t.Error(err)
 				return

--- a/base/v0_5_exp/validate_test.go
+++ b/base/v0_5_exp/validate_test.go
@@ -15,6 +15,7 @@
 package v0_5_exp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -127,10 +128,12 @@ func TestValidateResource(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -146,14 +149,16 @@ func TestValidateTree(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(path.New("yaml"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(path.New("yaml"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
-func TestValidateMode(t *testing.T) {
+func TestValidateFileMode(t *testing.T) {
 	fileTests := []struct {
 		in  File
 		out error
@@ -177,12 +182,16 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range fileTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
+}
 
+func TestValidateDirMode(t *testing.T) {
 	dirTests := []struct {
 		in  Directory
 		out error
@@ -206,10 +215,12 @@ func TestValidateMode(t *testing.T) {
 	}
 
 	for i, test := range dirTests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -270,9 +281,11 @@ func TestValidateFilesystem(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -79,7 +79,7 @@ func getTranslator(variant string, version semver.Version) (translator, error) {
 }
 
 // translators take a raw config and translate it to a raw Ignition config. The report returned should include any
-// errors, warnings, etc and may or may not be fatal. If report is fatal, or other errors are encountered while translating
+// errors, warnings, etc. and may or may not be fatal. If report is fatal, or other errors are encountered while translating
 // translators should return an error.
 type translator func([]byte, common.TranslateBytesOptions) ([]byte, report.Report, error)
 

--- a/config/fcos/v1_0/validate_test.go
+++ b/config/fcos/v1_0/validate_test.go
@@ -15,6 +15,7 @@
 package v1_0
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -101,10 +102,12 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_0Bytes([]byte(test.in), common.TranslateBytesOptions{})
-		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
-		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
-		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
-		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			_, r, _ := ToIgn3_0Bytes([]byte(test.in), common.TranslateBytesOptions{})
+			assert.Len(t, r.Entries, 1, "unexpected report length")
+			assert.Equal(t, test.message, r.Entries[0].Message, "bad error")
+			assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil")
+			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line")
+		})
 	}
 }

--- a/config/fcos/v1_1/validate_test.go
+++ b/config/fcos/v1_1/validate_test.go
@@ -15,6 +15,7 @@
 package v1_1
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -111,10 +112,12 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_1Bytes([]byte(test.in), common.TranslateBytesOptions{})
-		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
-		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
-		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
-		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			_, r, _ := ToIgn3_1Bytes([]byte(test.in), common.TranslateBytesOptions{})
+			assert.Len(t, r.Entries, 1, "unexpected report length")
+			assert.Equal(t, test.message, r.Entries[0].Message, "bad error")
+			assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil")
+			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line")
+		})
 	}
 }

--- a/config/fcos/v1_2/validate_test.go
+++ b/config/fcos/v1_2/validate_test.go
@@ -15,6 +15,7 @@
 package v1_2
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -111,10 +112,12 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_2Bytes([]byte(test.in), common.TranslateBytesOptions{})
-		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
-		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
-		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
-		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			_, r, _ := ToIgn3_2Bytes([]byte(test.in), common.TranslateBytesOptions{})
+			assert.Len(t, r.Entries, 1, "unexpected report length")
+			assert.Equal(t, test.message, r.Entries[0].Message, "bad error")
+			assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil")
+			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line")
+		})
 	}
 }

--- a/config/fcos/v1_3/translate_test.go
+++ b/config/fcos/v1_3/translate_test.go
@@ -15,6 +15,7 @@
 package v1_3
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -1410,10 +1411,12 @@ func TestTranslateBootDevice(t *testing.T) {
 	assert.Equal(t, bootV1SizeMiB, 384)
 
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, test.report, r, "#%d: report mismatch", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r, "report mismatch")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/config/fcos/v1_3/validate_test.go
+++ b/config/fcos/v1_3/validate_test.go
@@ -15,6 +15,7 @@
 package v1_3
 
 import (
+	"fmt"
 	"testing"
 
 	base "github.com/coreos/butane/base/v0_3"
@@ -115,11 +116,13 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_2Bytes([]byte(test.in), common.TranslateBytesOptions{})
-		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
-		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
-		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
-		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			_, r, _ := ToIgn3_2Bytes([]byte(test.in), common.TranslateBytesOptions{})
+			assert.Len(t, r.Entries, 1, "unexpected report length")
+			assert.Equal(t, test.message, r.Entries[0].Message, "bad error")
+			assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil")
+			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line")
+		})
 	}
 }
 
@@ -176,9 +179,11 @@ func TestValidateBootDevice(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad validation report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad validation report")
+		})
 	}
 }

--- a/config/fcos/v1_4/translate_test.go
+++ b/config/fcos/v1_4/translate_test.go
@@ -15,6 +15,7 @@
 package v1_4
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -1410,10 +1411,12 @@ func TestTranslateBootDevice(t *testing.T) {
 	assert.Equal(t, bootV1SizeMiB, 384)
 
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, test.report, r, "#%d: report mismatch", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r, "report mismatch")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/config/fcos/v1_4/validate_test.go
+++ b/config/fcos/v1_4/validate_test.go
@@ -15,6 +15,7 @@
 package v1_4
 
 import (
+	"fmt"
 	"testing"
 
 	base "github.com/coreos/butane/base/v0_4"
@@ -115,11 +116,13 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_3Bytes([]byte(test.in), common.TranslateBytesOptions{})
-		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
-		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
-		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
-		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			_, r, _ := ToIgn3_3Bytes([]byte(test.in), common.TranslateBytesOptions{})
+			assert.Len(t, r.Entries, 1, "unexpected report length")
+			assert.Equal(t, test.message, r.Entries[0].Message, "bad error")
+			assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil")
+			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line")
+		})
 	}
 }
 
@@ -176,9 +179,11 @@ func TestValidateBootDevice(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad validation report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad validation report")
+		})
 	}
 }

--- a/config/fcos/v1_5_exp/translate_test.go
+++ b/config/fcos/v1_5_exp/translate_test.go
@@ -15,6 +15,7 @@
 package v1_5_exp
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -1410,10 +1411,12 @@ func TestTranslateBootDevice(t *testing.T) {
 	assert.Equal(t, bootV1SizeMiB, 384)
 
 	for i, test := range tests {
-		actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, test.report, r, "#%d: report mimatch", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, test.report, r, "report mimatch")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/config/fcos/v1_5_exp/validate_test.go
+++ b/config/fcos/v1_5_exp/validate_test.go
@@ -15,6 +15,7 @@
 package v1_5_exp
 
 import (
+	"fmt"
 	"testing"
 
 	base "github.com/coreos/butane/base/v0_5_exp"
@@ -115,11 +116,13 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_4Bytes([]byte(test.in), common.TranslateBytesOptions{})
-		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
-		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
-		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
-		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			_, r, _ := ToIgn3_4Bytes([]byte(test.in), common.TranslateBytesOptions{})
+			assert.Len(t, r.Entries, 1, "unexpected report length")
+			assert.Equal(t, test.message, r.Entries[0].Message, "bad error")
+			assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil")
+			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line")
+		})
 	}
 }
 
@@ -176,9 +179,11 @@ func TestValidateBootDevice(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad validation report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad validation report")
+		})
 	}
 }

--- a/config/openshift/v4_10/translate.go
+++ b/config/openshift/v4_10/translate.go
@@ -225,9 +225,9 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "append"), common.ErrFileAppendSupport)
 		}
 		if file.Contents.Source != nil {
-			url, err := url.Parse(*file.Contents.Source)
+			fileSource, err := url.Parse(*file.Contents.Source)
 			// parse errors will be caught by normal config validation
-			if err == nil && url.Scheme != "data" {
+			if err == nil && fileSource.Scheme != "data" {
 				// FORBIDDEN
 				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
 			}

--- a/config/openshift/v4_10/translate_test.go
+++ b/config/openshift/v4_10/translate_test.go
@@ -15,6 +15,7 @@
 package v4_10
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -273,11 +274,13 @@ func TestTranslateConfig(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -461,12 +464,14 @@ func TestValidateSupport(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		var expectedReport report.Report
-		for _, entry := range test.entries {
-			expectedReport.AddOn(entry.path, entry.err, entry.kind)
-		}
-		actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expectedReport, r, "#%d: report mismatch", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.entries {
+				expectedReport.AddOn(entry.path, entry.err, entry.kind)
+			}
+			actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/config/openshift/v4_10/validate_test.go
+++ b/config/openshift/v4_10/validate_test.go
@@ -15,6 +15,7 @@
 package v4_10
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -64,10 +65,12 @@ func TestValidateMetadata(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -94,10 +97,12 @@ func TestValidateOpenShift(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -229,14 +234,16 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		for _, raw := range []bool{false, true} {
-			_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
-				Raw: raw,
-			})
-			assert.Len(t, r.Entries, 1, "#%d: unexpected report length, raw %v", i, raw)
-			assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error, raw %v", i, raw)
-			assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil, raw %v", i, raw)
-			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line, raw %v", i, raw)
-		}
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			for _, raw := range []bool{false, true} {
+				_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
+					Raw: raw,
+				})
+				assert.Len(t, r.Entries, 1, "unexpected report length, raw %v", raw)
+				assert.Equal(t, test.message, r.Entries[0].Message, "bad error, raw %v", raw)
+				assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil, raw %v", raw)
+				assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line, raw %v", raw)
+			}
+		})
 	}
 }

--- a/config/openshift/v4_11_exp/translate.go
+++ b/config/openshift/v4_11_exp/translate.go
@@ -238,9 +238,9 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "append"), common.ErrFileAppendSupport)
 		}
 		if file.Contents.Source != nil {
-			url, err := url.Parse(*file.Contents.Source)
+			fileSource, err := url.Parse(*file.Contents.Source)
 			// parse errors will be caught by normal config validation
-			if err == nil && url.Scheme != "data" {
+			if err == nil && fileSource.Scheme != "data" {
 				// FORBIDDEN
 				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
 			}

--- a/config/openshift/v4_11_exp/translate_test.go
+++ b/config/openshift/v4_11_exp/translate_test.go
@@ -15,6 +15,7 @@
 package v4_11_exp
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -273,11 +274,13 @@ func TestTranslateConfig(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -476,12 +479,14 @@ func TestValidateSupport(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		var expectedReport report.Report
-		for _, entry := range test.entries {
-			expectedReport.AddOn(entry.path, entry.err, entry.kind)
-		}
-		actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expectedReport, r, "#%d: report mismatch", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.entries {
+				expectedReport.AddOn(entry.path, entry.err, entry.kind)
+			}
+			actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/config/openshift/v4_11_exp/validate_test.go
+++ b/config/openshift/v4_11_exp/validate_test.go
@@ -15,6 +15,7 @@
 package v4_11_exp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -64,10 +65,12 @@ func TestValidateMetadata(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -94,10 +97,12 @@ func TestValidateOpenShift(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -229,14 +234,16 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		for _, raw := range []bool{false, true} {
-			_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
-				Raw: raw,
-			})
-			assert.Len(t, r.Entries, 1, "#%d: unexpected report length, raw %v", i, raw)
-			assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error, raw %v", i, raw)
-			assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil, raw %v", i, raw)
-			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line, raw %v", i, raw)
-		}
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			for _, raw := range []bool{false, true} {
+				_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
+					Raw: raw,
+				})
+				assert.Len(t, r.Entries, 1, "unexpected report length, raw %v", raw)
+				assert.Equal(t, test.message, r.Entries[0].Message, "bad error, raw %v", raw)
+				assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil, raw %v", raw)
+				assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line, raw %v", raw)
+			}
+		})
 	}
 }

--- a/config/openshift/v4_8/translate.go
+++ b/config/openshift/v4_8/translate.go
@@ -238,9 +238,9 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "compression"), common.ErrFileCompressionSupport)
 		}
 		if file.Contents.Source != nil {
-			url, err := url.Parse(*file.Contents.Source)
+			fileSource, err := url.Parse(*file.Contents.Source)
 			// parse errors will be caught by normal config validation
-			if err == nil && url.Scheme != "data" {
+			if err == nil && fileSource.Scheme != "data" {
 				// FORBIDDEN
 				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
 			}

--- a/config/openshift/v4_8/translate_test.go
+++ b/config/openshift/v4_8/translate_test.go
@@ -15,6 +15,7 @@
 package v4_8
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -344,11 +345,13 @@ func TestTranslateConfig(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -537,12 +540,14 @@ func TestValidateSupport(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		var expectedReport report.Report
-		for _, entry := range test.entries {
-			expectedReport.AddOn(entry.path, entry.err, entry.kind)
-		}
-		actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expectedReport, r, "#%d: report mismatch", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.entries {
+				expectedReport.AddOn(entry.path, entry.err, entry.kind)
+			}
+			actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/config/openshift/v4_8/validate_test.go
+++ b/config/openshift/v4_8/validate_test.go
@@ -15,6 +15,7 @@
 package v4_8
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -64,10 +65,12 @@ func TestValidateMetadata(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -94,10 +97,12 @@ func TestValidateOpenShift(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -229,14 +234,16 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		for _, raw := range []bool{false, true} {
-			_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
-				Raw: raw,
-			})
-			assert.Len(t, r.Entries, 1, "#%d: unexpected report length, raw %v", i, raw)
-			assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error, raw %v", i, raw)
-			assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil, raw %v", i, raw)
-			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line, raw %v", i, raw)
-		}
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			for _, raw := range []bool{false, true} {
+				_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
+					Raw: raw,
+				})
+				assert.Len(t, r.Entries, 1, "unexpected report length, raw %v", raw)
+				assert.Equal(t, test.message, r.Entries[0].Message, "bad error, raw %v", raw)
+				assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil, raw %v", raw)
+				assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line, raw %v", raw)
+			}
+		})
 	}
 }

--- a/config/openshift/v4_9/translate.go
+++ b/config/openshift/v4_9/translate.go
@@ -238,9 +238,9 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "compression"), common.ErrFileCompressionSupport)
 		}
 		if file.Contents.Source != nil {
-			url, err := url.Parse(*file.Contents.Source)
+			fileSource, err := url.Parse(*file.Contents.Source)
 			// parse errors will be caught by normal config validation
-			if err == nil && url.Scheme != "data" {
+			if err == nil && fileSource.Scheme != "data" {
 				// FORBIDDEN
 				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
 			}

--- a/config/openshift/v4_9/translate_test.go
+++ b/config/openshift/v4_9/translate_test.go
@@ -15,6 +15,7 @@
 package v4_9
 
 import (
+	"fmt"
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
@@ -344,11 +345,13 @@ func TestTranslateConfig(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
-		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
-		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, test.out, actual, "translation mismatch")
+			assert.Equal(t, report.Report{}, r, "non-empty report")
+			baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }
 
@@ -537,12 +540,14 @@ func TestValidateSupport(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		var expectedReport report.Report
-		for _, entry := range test.entries {
-			expectedReport.AddOn(entry.path, entry.err, entry.kind)
-		}
-		actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
-		assert.Equal(t, expectedReport, r, "#%d: report mismatch", i)
-		assert.NoError(t, translations.DebugVerifyCoverage(actual), "#%d: incomplete TranslationSet coverage", i)
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.entries {
+				expectedReport.AddOn(entry.path, entry.err, entry.kind)
+			}
+			actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
 	}
 }

--- a/config/openshift/v4_9/validate_test.go
+++ b/config/openshift/v4_9/validate_test.go
@@ -15,6 +15,7 @@
 package v4_9
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -64,10 +65,12 @@ func TestValidateMetadata(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -94,10 +97,12 @@ func TestValidateOpenShift(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad report", i)
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			actual := test.in.Validate(path.New("yaml"))
+			expected := report.Report{}
+			expected.AddOnError(test.errPath, test.out)
+			assert.Equal(t, expected, actual, "bad report")
+		})
 	}
 }
 
@@ -229,14 +234,16 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		for _, raw := range []bool{false, true} {
-			_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
-				Raw: raw,
-			})
-			assert.Len(t, r.Entries, 1, "#%d: unexpected report length, raw %v", i, raw)
-			assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error, raw %v", i, raw)
-			assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil, raw %v", i, raw)
-			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line, raw %v", i, raw)
-		}
+		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
+			for _, raw := range []bool{false, true} {
+				_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
+					Raw: raw,
+				})
+				assert.Len(t, r.Entries, 1, "unexpected report length, raw %v", raw)
+				assert.Equal(t, test.message, r.Entries[0].Message, "bad error, raw %v", raw)
+				assert.NotNil(t, r.Entries[0].Marker.StartP, "marker start is nil, raw %v", raw)
+				assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "incorrect error line, raw %v", raw)
+			}
+		})
 	}
 }

--- a/config/util/util_test.go
+++ b/config/util/util_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/butane/config/common"
@@ -50,9 +51,11 @@ func TestSnake(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if snake(test.in) != test.out {
-			t.Errorf("#%d: expected %q got %q", i, test.out, snake(test.in))
-		}
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			if snake(test.in) != test.out {
+				t.Errorf("expected %q got %q", test.out, snake(test.in))
+			}
+		})
 	}
 }
 

--- a/docs/config-fcos-v1_0.md
+++ b/docs/config-fcos-v1_0.md
@@ -35,7 +35,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-fcos-v1_1.md
+++ b/docs/config-fcos-v1_1.md
@@ -57,7 +57,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-fcos-v1_2.md
+++ b/docs/config-fcos-v1_2.md
@@ -57,7 +57,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-fcos-v1_3.md
+++ b/docs/config-fcos-v1_3.md
@@ -57,7 +57,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-fcos-v1_4.md
+++ b/docs/config-fcos-v1_4.md
@@ -57,7 +57,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-fcos-v1_5-exp.md
+++ b/docs/config-fcos-v1_5-exp.md
@@ -59,7 +59,7 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-openshift-v4_10.md
+++ b/docs/config-openshift-v4_10.md
@@ -60,7 +60,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-openshift-v4_8.md
+++ b/docs/config-openshift-v4_8.md
@@ -57,7 +57,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -57,7 +57,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/config-rhcos-v0_1.md
+++ b/docs/config-rhcos-v0_1.md
@@ -57,7 +57,7 @@ The RHEL CoreOS configuration is a YAML document conforming to the following spe
     * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
       * **_label_** (string): the PARTLABEL for the partition.
-      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
       * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
       * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
       * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -163,7 +163,7 @@ storage:
 
 ### Filesystems and partitions
 
-This example creates a single partition spanning all of the `sdb` device then creates a btrfs filesystem on it to use as `/var`. Finally it creates the mount unit for systemd so it gets mounted on boot.
+This example creates a single partition spanning all of the `sdb` device then creates a btrfs filesystem on it to use as `/var`. Finally, it creates the mount unit for systemd so it gets mounted on boot.
 
 <!-- butane-config -->
 ```yaml

--- a/internal/main.go
+++ b/internal/main.go
@@ -79,8 +79,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	var infile *os.File = os.Stdin
-	var outfile *os.File = os.Stdout
+	infile := os.Stdin
+	outfile := os.Stdout
 	if input != "" {
 		var err error
 		infile, err = os.Open(input)

--- a/translate/set.go
+++ b/translate/set.go
@@ -99,8 +99,8 @@ func (ts TranslationSet) AddTranslation(from, to path.ContextPath) {
 func (ts TranslationSet) AddFromCommonSource(common path.ContextPath, toPrefix path.ContextPath, to interface{}) {
 	v := reflect.ValueOf(to)
 	vPaths := prefixPaths(getAllPaths(v, ts.ToTag, true), toPrefix.Path...)
-	for _, path := range vPaths {
-		ts.AddTranslation(common, path)
+	for _, toPath := range vPaths {
+		ts.AddTranslation(common, toPath)
 	}
 	ts.AddTranslation(common, toPrefix)
 }
@@ -165,9 +165,9 @@ OUTER:
 // error listing them.
 func (ts TranslationSet) DebugVerifyCoverage(v interface{}) error {
 	var missingPaths []string
-	for _, path := range getAllPaths(reflect.ValueOf(v), ts.ToTag, false) {
-		if _, ok := ts.Set[path.String()]; !ok {
-			missingPaths = append(missingPaths, path.String())
+	for _, pathToCheck := range getAllPaths(reflect.ValueOf(v), ts.ToTag, false) {
+		if _, ok := ts.Set[pathToCheck.String()]; !ok {
+			missingPaths = append(missingPaths, pathToCheck.String())
 		}
 	}
 	if len(missingPaths) > 0 {

--- a/translate/util.go
+++ b/translate/util.go
@@ -126,8 +126,8 @@ func MergeP(tr Translator, tm TranslationSet, r *report.Report, prefix interface
 // Utility function to run a translation and merge the result, with the
 // specified prefixes, into the specified TranslationSet and Report.
 func MergeP2(tr Translator, tm TranslationSet, r *report.Report, fromPrefix interface{}, from interface{}, toPrefix interface{}, to interface{}) {
-	translations, report := tr.Translate(from, to)
+	translations, translationReport := tr.Translate(from, to)
 	tm.MergeP2(fromPrefix, toPrefix, translations)
 	// translation report paths are on the from side
-	r.Merge(PrefixReport(report, fromPrefix))
+	r.Merge(PrefixReport(translationReport, fromPrefix))
 }


### PR DESCRIPTION
While working on #289 I stumbled across a number of nitpicks and things I would've done differently based on the supported Go version (1.15 in go.mod).

Grouped by individual commits in this pull request I did the following things:

- fix some (obvious) typos
- use `t.TempDir` in tests: a Go managed temporary directory automatically cleaned up at the end of tests, available since Go 1.15
- Prevent shadowing of imports
- Remove unnecessary typing of particular variable declarations
- Blank some unused method parameters
- Use Go subtests (available since Go 1.7) instead of simple loops. This allows better debugging in case of errors because the faulty iteration will now tell us which input in particular failed while running through all of them at all times.