### PR TITLE
templates/release-checklist: update example ticket links

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -32,8 +32,8 @@ Packaging:
 
 GitHub release:
  - [ ] Wait until the Bodhi update shows "Signed :heavy_check_mark:" in the Metadata box.
- - [ ] [File a releng ticket](https://pagure.io/releng/new_issue) based on [prior signing tickets](https://pagure.io/releng/issue/10158).
-   - [ ] Update the script and test it locally by dropping the `sigul` lines.
+ - [ ] [File a releng ticket](https://pagure.io/releng/new_issue) based on [prior signing tickets](https://pagure.io/releng/issue/10599).
+   - [ ] Update the script and test it locally by running it like `FAKESIGN=1 ./script`
      - [ ] If a new Fedora release has gone stable, update the signing key in the script to use the new Fedora signing key [found here](https://getfedora.org/security).
  - [ ] Ping `mboddu` in Libera.Chat `#fedora-coreos`, linking to the ticket
  - [ ] Wait for the ticket to be closed
@@ -55,5 +55,5 @@ Housekeeping:
    - [ ] Update the dist-git repo, following the instructions above
    - [ ] PR the changes
    - [ ] When the PR lands, build the package
- - [ ] File ticket similar to [this one](https://issues.redhat.com/browse/ART-3043) to sync the new version to mirror.openshift.com
+ - [ ] File ticket similar to [this one](https://issues.redhat.com/browse/ART-3711) to sync the new version to mirror.openshift.com
  - [ ] Ask bgilbert to update the [MacPorts package](https://github.com/macports/macports-ports/tree/master/sysutils/butane)


### PR DESCRIPTION
The new releng signing script gets all binaries from the `-redistributable` subpackage, uses the F35 key, and can skip the sigul run if requested by an environment variable.

The new ART sync ticket drops one-time introductory language.