### PR TITLE
Add CI on macOS and Windows; fix Windows path handling and tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,13 @@ jobs:
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x, 1.17.x]
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest]
+        include:
+        - go-version: 1.17.x
+          os: macos-latest
+        - go-version: 1.17.x
+          os: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -24,9 +30,11 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
     - name: Run tests
+      shell: bash
       run: ./test
     - name: Run linter
       uses: golangci/golangci-lint-action@v2
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
         version: v1.42.0
         args: -E=gofmt --timeout=30m0s

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -17,6 +17,7 @@ package v0_2
 import (
 	"io/ioutil"
 	"os"
+	slashpath "path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -127,7 +128,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 
 		// calculate file path within FilesDir and check for
 		// path traversal
-		filePath := filepath.Join(options.FilesDir, *from.Local)
+		filePath := filepath.Join(options.FilesDir, filepath.FromSlash(*from.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
 			r.AddOnError(c, err)
 			return
@@ -208,7 +209,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 
 		// calculate base path within FilesDir and check for
 		// path traversal
-		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
+		srcBaseDir := filepath.Join(options.FilesDir, filepath.FromSlash(tree.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
@@ -246,7 +247,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 			r.AddOnError(yamlPath, err)
 			return nil
 		}
-		destPath := filepath.Join(destBaseDir, relPath)
+		destPath := slashpath.Join(destBaseDir, filepath.ToSlash(relPath))
 
 		if info.Mode().IsDir() {
 			return nil
@@ -319,11 +320,12 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "links"))
 				}
 			}
-			link.Target, err = os.Readlink(srcPath)
+			target, err := os.Readlink(srcPath)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
+			link.Target = filepath.ToSlash(target)
 			ts.AddTranslation(yamlPath, path.New("json", "storage", "links", i, "target"))
 		} else {
 			r.AddOnError(yamlPath, common.ErrFileType)

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -36,6 +37,21 @@ import (
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
+
+var (
+	osStatName string
+	osNotFound string
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		osStatName = "CreateFile"
+		osNotFound = "The system cannot find the file specified."
+	} else {
+		osStatName = "stat"
+		osNotFound = "no such file or directory"
+	}
+}
 
 // TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entries.
 func TestTranslateFile(t *testing.T) {
@@ -349,7 +365,7 @@ func TestTranslateFile(t *testing.T) {
 				},
 			},
 			[]translate.Translation{},
-			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": no such file or directory\n",
+			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": " + osNotFound + "\n",
 			common.TranslateOptions{
 				FilesDir: filesDir,
 			},
@@ -1265,7 +1281,7 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrTreeNotDirectory.Error() + "\n" +
-				"error at $.storage.trees.1: stat %FilesDir%/nonexistent: no such file or directory\n",
+				"error at $.storage.trees.1: " + osStatName + " %FilesDir%" + string(filepath.Separator) + "nonexistent: " + osNotFound + "\n",
 		},
 	}
 

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -46,11 +46,16 @@ func TestTranslateFile(t *testing.T) {
 
 	filesDir := t.TempDir()
 	fileContents := map[string]string{
-		"file-1": "file contents\n",
-		"file-2": zzz,
-		"file-3": random,
+		"file-1":        "file contents\n",
+		"file-2":        zzz,
+		"file-3":        random,
+		"subdir/file-4": "subdir file contents\n",
 	}
 	for name, contents := range fileContents {
+		if err := os.MkdirAll(filepath.Join(filesDir, filepath.Dir(name)), 0755); err != nil {
+			t.Error(err)
+			return
+		}
 		err := ioutil.WriteFile(filepath.Join(filesDir, name), []byte(contents), 0644)
 		if err != nil {
 			t.Error(err)
@@ -251,6 +256,35 @@ func TestTranslateFile(t *testing.T) {
 				FileEmbedded1: types.FileEmbedded1{
 					Contents: types.Resource{
 						Source: util.StrToPtr("data:,file%20contents%0A"),
+					},
+				},
+			},
+			[]translate.Translation{
+				{
+					From: path.New("yaml", "contents", "local"),
+					To:   path.New("json", "contents", "source"),
+				},
+			},
+			"",
+			common.TranslateOptions{
+				FilesDir: filesDir,
+			},
+		},
+		// local file in subdirectory
+		{
+			File{
+				Path: "/foo",
+				Contents: Resource{
+					Local: util.StrToPtr("subdir/file-4"),
+				},
+			},
+			types.File{
+				Node: types.Node{
+					Path: "/foo",
+				},
+				FileEmbedded1: types.FileEmbedded1{
+					Contents: types.Resource{
+						Source: util.StrToPtr("data:,subdir%20file%20contents%0A"),
 					},
 				},
 			},
@@ -1239,7 +1273,7 @@ func TestTranslateTree(t *testing.T) {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			filesDir := t.TempDir()
 			for testPath, mode := range test.dirDirs {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(absPath, 0755); err != nil {
 					t.Error(err)
 					return
@@ -1250,7 +1284,7 @@ func TestTranslateTree(t *testing.T) {
 				}
 			}
 			for testPath, mode := range test.dirFiles {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 					t.Error(err)
 					return
@@ -1261,7 +1295,7 @@ func TestTranslateTree(t *testing.T) {
 				}
 			}
 			for testPath, target := range test.dirLinks {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 					t.Error(err)
 					return
@@ -1272,7 +1306,7 @@ func TestTranslateTree(t *testing.T) {
 				}
 			}
 			for _, testPath := range test.dirSockets {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 					t.Error(err)
 					return

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -884,6 +884,7 @@ func TestTranslateTree(t *testing.T) {
 		outFiles   []types.File
 		outLinks   []types.Link
 		report     string
+		skip       func(t *testing.T)
 	}{
 		// smoke test
 		{},
@@ -974,7 +975,14 @@ func TestTranslateTree(t *testing.T) {
 						Contents: types.Resource{
 							Source: util.StrToPtr("data:,tree%2Fexecutable"),
 						},
-						Mode: util.IntToPtr(0755),
+						Mode: util.IntToPtr(func() int {
+							if runtime.GOOS != "windows" {
+								return 0755
+							} else {
+								// Windows doesn't have executable bits
+								return 0644
+							}
+						}()),
 					},
 				},
 				{
@@ -1266,6 +1274,13 @@ func TestTranslateTree(t *testing.T) {
 			report: "error at $.storage.trees.0: open %FilesDir%/tree/file: permission denied\n" +
 				"error at $.storage.trees.0: open %FilesDir%/tree/subdir: permission denied\n" +
 				"error at $.storage.trees.1: open %FilesDir%/tree2: permission denied\n",
+			skip: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					// os.Chmod() only respects the writable bit and there
+					// isn't a trivial way to make inodes inaccessible
+					t.Skip("skipping test on Windows")
+				}
+			},
 		},
 		// local is not a directory
 		{
@@ -1287,6 +1302,10 @@ func TestTranslateTree(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			if test.skip != nil {
+				// give the test an opportunity to skip
+				test.skip(t)
+			}
 			filesDir := t.TempDir()
 			for testPath, mode := range test.dirDirs {
 				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -1253,6 +1253,13 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrFileType.Error() + "\n",
+			skip: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					// Windows supports Unix domain sockets, but os.Stat()
+					// doesn't detect them correctly.
+					t.Skip("skipping test due to https://github.com/golang/go/issues/33357")
+				}
+			},
 		},
 		// unreadable file
 		{

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	slashpath "path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -138,7 +139,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 
 		// calculate file path within FilesDir and check for
 		// path traversal
-		filePath := filepath.Join(options.FilesDir, *from.Local)
+		filePath := filepath.Join(options.FilesDir, filepath.FromSlash(*from.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
 			r.AddOnError(c, err)
 			return
@@ -219,7 +220,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 
 		// calculate base path within FilesDir and check for
 		// path traversal
-		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
+		srcBaseDir := filepath.Join(options.FilesDir, filepath.FromSlash(tree.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
@@ -257,7 +258,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 			r.AddOnError(yamlPath, err)
 			return nil
 		}
-		destPath := filepath.Join(destBaseDir, relPath)
+		destPath := slashpath.Join(destBaseDir, filepath.ToSlash(relPath))
 
 		if info.Mode().IsDir() {
 			return nil
@@ -330,11 +331,12 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "links"))
 				}
 			}
-			link.Target, err = os.Readlink(srcPath)
+			target, err := os.Readlink(srcPath)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
+			link.Target = filepath.ToSlash(target)
 			ts.AddTranslation(yamlPath, path.New("json", "storage", "links", i, "target"))
 		} else {
 			r.AddOnError(yamlPath, common.ErrFileType)

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -46,11 +46,16 @@ func TestTranslateFile(t *testing.T) {
 
 	filesDir := t.TempDir()
 	fileContents := map[string]string{
-		"file-1": "file contents\n",
-		"file-2": zzz,
-		"file-3": random,
+		"file-1":        "file contents\n",
+		"file-2":        zzz,
+		"file-3":        random,
+		"subdir/file-4": "subdir file contents\n",
 	}
 	for name, contents := range fileContents {
+		if err := os.MkdirAll(filepath.Join(filesDir, filepath.Dir(name)), 0755); err != nil {
+			t.Error(err)
+			return
+		}
 		err := ioutil.WriteFile(filepath.Join(filesDir, name), []byte(contents), 0644)
 		if err != nil {
 			t.Error(err)
@@ -251,6 +256,35 @@ func TestTranslateFile(t *testing.T) {
 				FileEmbedded1: types.FileEmbedded1{
 					Contents: types.Resource{
 						Source: util.StrToPtr("data:,file%20contents%0A"),
+					},
+				},
+			},
+			[]translate.Translation{
+				{
+					From: path.New("yaml", "contents", "local"),
+					To:   path.New("json", "contents", "source"),
+				},
+			},
+			"",
+			common.TranslateOptions{
+				FilesDir: filesDir,
+			},
+		},
+		// local file in subdirectory
+		{
+			File{
+				Path: "/foo",
+				Contents: Resource{
+					Local: util.StrToPtr("subdir/file-4"),
+				},
+			},
+			types.File{
+				Node: types.Node{
+					Path: "/foo",
+				},
+				FileEmbedded1: types.FileEmbedded1{
+					Contents: types.Resource{
+						Source: util.StrToPtr("data:,subdir%20file%20contents%0A"),
 					},
 				},
 			},
@@ -1319,7 +1353,7 @@ func TestTranslateTree(t *testing.T) {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			filesDir := t.TempDir()
 			for testPath, mode := range test.dirDirs {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(absPath, 0755); err != nil {
 					t.Error(err)
 					return
@@ -1330,7 +1364,7 @@ func TestTranslateTree(t *testing.T) {
 				}
 			}
 			for testPath, mode := range test.dirFiles {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 					t.Error(err)
 					return
@@ -1341,7 +1375,7 @@ func TestTranslateTree(t *testing.T) {
 				}
 			}
 			for testPath, target := range test.dirLinks {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 					t.Error(err)
 					return
@@ -1352,7 +1386,7 @@ func TestTranslateTree(t *testing.T) {
 				}
 			}
 			for _, testPath := range test.dirSockets {
-				absPath := filepath.Join(filesDir, testPath)
+				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))
 				if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 					t.Error(err)
 					return

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -36,6 +37,21 @@ import (
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
+
+var (
+	osStatName string
+	osNotFound string
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		osStatName = "CreateFile"
+		osNotFound = "The system cannot find the file specified."
+	} else {
+		osStatName = "stat"
+		osNotFound = "no such file or directory"
+	}
+}
 
 // TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entries.
 func TestTranslateFile(t *testing.T) {
@@ -349,7 +365,7 @@ func TestTranslateFile(t *testing.T) {
 				},
 			},
 			[]translate.Translation{},
-			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": no such file or directory\n",
+			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": " + osNotFound + "\n",
 			common.TranslateOptions{
 				FilesDir: filesDir,
 			},
@@ -1345,7 +1361,7 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrTreeNotDirectory.Error() + "\n" +
-				"error at $.storage.trees.1: stat %FilesDir%/nonexistent: no such file or directory\n",
+				"error at $.storage.trees.1: " + osStatName + " %FilesDir%" + string(filepath.Separator) + "nonexistent: " + osNotFound + "\n",
 		},
 	}
 

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -1333,6 +1333,13 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrFileType.Error() + "\n",
+			skip: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					// Windows supports Unix domain sockets, but os.Stat()
+					// doesn't detect them correctly.
+					t.Skip("skipping test due to https://github.com/golang/go/issues/33357")
+				}
+			},
 		},
 		// unreadable file
 		{

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -964,6 +964,7 @@ func TestTranslateTree(t *testing.T) {
 		outFiles   []types.File
 		outLinks   []types.Link
 		report     string
+		skip       func(t *testing.T)
 	}{
 		// smoke test
 		{},
@@ -1054,7 +1055,14 @@ func TestTranslateTree(t *testing.T) {
 						Contents: types.Resource{
 							Source: util.StrToPtr("data:,tree%2Fexecutable"),
 						},
-						Mode: util.IntToPtr(0755),
+						Mode: util.IntToPtr(func() int {
+							if runtime.GOOS != "windows" {
+								return 0755
+							} else {
+								// Windows doesn't have executable bits
+								return 0644
+							}
+						}()),
 					},
 				},
 				{
@@ -1346,6 +1354,13 @@ func TestTranslateTree(t *testing.T) {
 			report: "error at $.storage.trees.0: open %FilesDir%/tree/file: permission denied\n" +
 				"error at $.storage.trees.0: open %FilesDir%/tree/subdir: permission denied\n" +
 				"error at $.storage.trees.1: open %FilesDir%/tree2: permission denied\n",
+			skip: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					// os.Chmod() only respects the writable bit and there
+					// isn't a trivial way to make inodes inaccessible
+					t.Skip("skipping test on Windows")
+				}
+			},
 		},
 		// local is not a directory
 		{
@@ -1367,6 +1382,10 @@ func TestTranslateTree(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			if test.skip != nil {
+				// give the test an opportunity to skip
+				test.skip(t)
+			}
 			filesDir := t.TempDir()
 			for testPath, mode := range test.dirDirs {
 				absPath := filepath.Join(filesDir, filepath.FromSlash(testPath))

--- a/base/v0_4/translate.go
+++ b/base/v0_4/translate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	slashpath "path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -153,7 +154,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 
 		// calculate file path within FilesDir and check for
 		// path traversal
-		filePath := filepath.Join(options.FilesDir, *from.Local)
+		filePath := filepath.Join(options.FilesDir, filepath.FromSlash(*from.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
 			r.AddOnError(c, err)
 			return
@@ -234,7 +235,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 
 		// calculate base path within FilesDir and check for
 		// path traversal
-		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
+		srcBaseDir := filepath.Join(options.FilesDir, filepath.FromSlash(tree.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
@@ -272,7 +273,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 			r.AddOnError(yamlPath, err)
 			return nil
 		}
-		destPath := filepath.Join(destBaseDir, relPath)
+		destPath := slashpath.Join(destBaseDir, filepath.ToSlash(relPath))
 
 		if info.Mode().IsDir() {
 			return nil
@@ -350,7 +351,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			link.Target = &target
+			link.Target = util.StrToPtr(filepath.ToSlash(target))
 			ts.AddTranslation(yamlPath, path.New("json", "storage", "links", i, "target"))
 		} else {
 			r.AddOnError(yamlPath, common.ErrFileType)

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -36,6 +37,21 @@ import (
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
+
+var (
+	osStatName string
+	osNotFound string
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		osStatName = "CreateFile"
+		osNotFound = "The system cannot find the file specified."
+	} else {
+		osStatName = "stat"
+		osNotFound = "no such file or directory"
+	}
+}
 
 // TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entries.
 func TestTranslateFile(t *testing.T) {
@@ -349,7 +365,7 @@ func TestTranslateFile(t *testing.T) {
 				},
 			},
 			[]translate.Translation{},
-			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": no such file or directory\n",
+			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": " + osNotFound + "\n",
 			common.TranslateOptions{
 				FilesDir: filesDir,
 			},
@@ -1430,7 +1446,7 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrTreeNotDirectory.Error() + "\n" +
-				"error at $.storage.trees.1: stat %FilesDir%/nonexistent: no such file or directory\n",
+				"error at $.storage.trees.1: " + osStatName + " %FilesDir%" + string(filepath.Separator) + "nonexistent: " + osNotFound + "\n",
 		},
 	}
 

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -1418,6 +1418,13 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrFileType.Error() + "\n",
+			skip: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					// Windows supports Unix domain sockets, but os.Stat()
+					// doesn't detect them correctly.
+					t.Skip("skipping test due to https://github.com/golang/go/issues/33357")
+				}
+			},
 		},
 		// unreadable file
 		{

--- a/base/v0_5_exp/translate.go
+++ b/base/v0_5_exp/translate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	slashpath "path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -153,7 +154,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 
 		// calculate file path within FilesDir and check for
 		// path traversal
-		filePath := filepath.Join(options.FilesDir, *from.Local)
+		filePath := filepath.Join(options.FilesDir, filepath.FromSlash(*from.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
 			r.AddOnError(c, err)
 			return
@@ -234,7 +235,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 
 		// calculate base path within FilesDir and check for
 		// path traversal
-		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
+		srcBaseDir := filepath.Join(options.FilesDir, filepath.FromSlash(tree.Local))
 		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
@@ -272,7 +273,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 			r.AddOnError(yamlPath, err)
 			return nil
 		}
-		destPath := filepath.Join(destBaseDir, relPath)
+		destPath := slashpath.Join(destBaseDir, filepath.ToSlash(relPath))
 
 		if info.Mode().IsDir() {
 			return nil
@@ -350,7 +351,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			link.Target = &target
+			link.Target = util.StrToPtr(filepath.ToSlash(target))
 			ts.AddTranslation(yamlPath, path.New("json", "storage", "links", i, "target"))
 		} else {
 			r.AddOnError(yamlPath, common.ErrFileType)

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -36,6 +37,21 @@ import (
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
+
+var (
+	osStatName string
+	osNotFound string
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		osStatName = "CreateFile"
+		osNotFound = "The system cannot find the file specified."
+	} else {
+		osStatName = "stat"
+		osNotFound = "no such file or directory"
+	}
+}
 
 // TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entries.
 func TestTranslateFile(t *testing.T) {
@@ -349,7 +365,7 @@ func TestTranslateFile(t *testing.T) {
 				},
 			},
 			[]translate.Translation{},
-			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": no such file or directory\n",
+			"error at $.contents.local: open " + filepath.Join(filesDir, "file-missing") + ": " + osNotFound + "\n",
 			common.TranslateOptions{
 				FilesDir: filesDir,
 			},
@@ -1430,7 +1446,7 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrTreeNotDirectory.Error() + "\n" +
-				"error at $.storage.trees.1: stat %FilesDir%/nonexistent: no such file or directory\n",
+				"error at $.storage.trees.1: " + osStatName + " %FilesDir%" + string(filepath.Separator) + "nonexistent: " + osNotFound + "\n",
 		},
 	}
 

--- a/base/v0_5_exp/translate_test.go
+++ b/base/v0_5_exp/translate_test.go
@@ -1418,6 +1418,13 @@ func TestTranslateTree(t *testing.T) {
 				},
 			},
 			report: "error at $.storage.trees.0: " + common.ErrFileType.Error() + "\n",
+			skip: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					// Windows supports Unix domain sockets, but os.Stat()
+					// doesn't detect them correctly.
+					t.Skip("skipping test due to https://github.com/golang/go/issues/33357")
+				}
+			},
 		},
 		// unreadable file
 		{

--- a/build
+++ b/build
@@ -10,9 +10,8 @@ LDFLAGS="-w -X github.com/coreos/butane/internal/version.Raw=$version"
 
 NAME=butane
 
-eval $(go env)
 if [ -z ${BIN_PATH+a} ]; then
-	BIN_PATH=${PWD}/bin/${GOARCH}
+	BIN_PATH=${PWD}/bin/$(go env GOARCH)
 fi
 
 echo "Building $NAME..."

--- a/test
+++ b/test
@@ -21,29 +21,34 @@ source ./build
 echo "Running tests"
 go test ./... -cover
 
-echo "Checking docs"
-shopt -s nullglob
-mkdir tmpdocs
-trap 'rm -r tmpdocs' EXIT
-# Create files-dir contents expected by configs
-mkdir -p tmpdocs/files-dir/tree
-touch tmpdocs/files-dir/{config.ign,ca.pem,file,file-epilogue,local-file3}
+if [ "$(go env GOOS)" = linux ]; then
+    echo "Checking docs"
+    shopt -s nullglob
+    mkdir tmpdocs
+    trap 'rm -r tmpdocs' EXIT
+    # Create files-dir contents expected by configs
+    mkdir -p tmpdocs/files-dir/tree
+    touch tmpdocs/files-dir/{config.ign,ca.pem,file,file-epilogue,local-file3}
 
-for doc in docs/*md
-do
-	echo "Checking $doc"
-	# split each doc into a bunch of tmpfiles then run butane on them
-	sed -n '/^<!-- butane-config -->/,/^```$/ p' < ${doc} \
-		| csplit - '/<!-- butane-config -->/' '{*}' -z --prefix "tmpdocs/config_$(basename ${doc%.*})_" -q
+    for doc in docs/*md
+    do
+            echo "Checking $doc"
+            # split each doc into a bunch of tmpfiles then run butane on them
+            sed -n '/^<!-- butane-config -->/,/^```$/ p' < ${doc} \
+                    | csplit - '/<!-- butane-config -->/' '{*}' -z --prefix "tmpdocs/config_$(basename ${doc%.*})_" -q
 
-	for i in tmpdocs/config_*
-	do
-		echo "Checking $i"
-		cat "$i" | tail -n +3 | head -n -1 \
-			| ${BIN_PATH}/${NAME} --strict --files-dir tmpdocs/files-dir > /dev/null \
-			|| (cat -n "$i" && false)
-	done
-	rm -f tmpdocs/config_*
-done
+            for i in tmpdocs/config_*
+            do
+                    echo "Checking $i"
+                    cat "$i" | tail -n +3 | head -n -1 \
+                            | ${BIN_PATH}/${NAME} --strict --files-dir tmpdocs/files-dir > /dev/null \
+                            || (cat -n "$i" && false)
+            done
+            rm -f tmpdocs/config_*
+    done
+else
+    # Avoid dealing with presence/behavior of csplit
+    echo "skipping docs check on non-Linux"
+fi
 
 echo ok


### PR DESCRIPTION
We build releases on those platforms, so let's check them in CI.  To reduce CI resources, only check with the latest Go version, and skip linting.  Disable individual checks in `./test` on platforms where they can't be easily supported.

Also fix path separator confusion on Windows, affecting trees and `Resource.Local`, and fix or disable broken tests.