### PR TITLE
NEWS: add missing entry for 0.14.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@
   Bug Fixes:
 
     - Correctly fail on validation warnings if --strict is specified
+    - Statically link official Linux binaries
 
   Misc Changes:
 


### PR DESCRIPTION
We're now statically linking the Linux release binaries.  That change wasn't strictly in this repo, but it's user-visible.