### PR TITLE
ci: add testing using go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,12 +14,12 @@ jobs:
     name: Test build
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
         os: [ubuntu-latest]
         include:
-        - go-version: 1.17.x
+        - go-version: 1.18.x
           os: macos-latest
-        - go-version: 1.17.x
+        - go-version: 1.18.x
           os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,5 +36,5 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
-        version: v1.42.0
+        version: v1.45.0
         args: -E=gofmt --timeout=30m0s


### PR DESCRIPTION
Expanded the list of OS used to include mac + windows; flipped the
logic to exclude combinations of go + mac/windows we don't want to
test.