### PR TITLE
workflows: build and push container from GitHub Actions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,18 +3,31 @@ name: Container
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 
 permissions:
   contents: read
 
+# avoid races when pushing containers built from main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   build-container:
-    name: "Build container image"
+    name: Build container image
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build container image
-        run: podman build .
+        with:
+          # fetch tags so the compiled-in version number is useful
+          fetch-depth: 0
+      - name: Build and push container
+        uses: coreos/actions-lib/build-container@main
+        with:
+          credentials: ${{ secrets.QUAY_AUTH }}
+          push: quay.io/coreos/butane quay.io/coreos/fcct
+          # Speed up PR CI by skipping arm64
+          pr-arches: amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:35 AS builder
-RUN dnf install -y golang git
+RUN dnf install -y golang git-core
 RUN mkdir /butane
 COPY . /butane
 WORKDIR /butane

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ WORKDIR /butane
 RUN ./build_for_container
 
 FROM scratch
-COPY --from=builder /butane/bin/container/butane-x86_64-unknown-linux-gnu /usr/local/bin/butane
+COPY --from=builder /butane/bin/container/butane /usr/local/bin/butane
 ENTRYPOINT ["/usr/local/bin/butane"]

--- a/build_for_container
+++ b/build_for_container
@@ -14,5 +14,4 @@ if [ -z ${BIN_PATH+a} ]; then
 fi
 
 export GOOS=linux
-export GOARCH=amd64
 go build -o ${BIN_PATH}/butane -ldflags "$LDFLAGS" internal/main.go

--- a/build_for_container
+++ b/build_for_container
@@ -13,12 +13,6 @@ if [ -z ${BIN_PATH+a} ]; then
 	export BIN_PATH=${PWD}/bin/container/
 fi
 
-build_release() {
-    export NAME="butane-${1}"
-    echo "building ${NAME}"
-    go build -o ${BIN_PATH}/${NAME} -ldflags "$LDFLAGS" internal/main.go
-}
-
 export GOOS=linux
 export GOARCH=amd64
-build_release x86_64-unknown-linux-gnu
+go build -o ${BIN_PATH}/butane -ldflags "$LDFLAGS" internal/main.go


### PR DESCRIPTION
Quay builds are amd64-only and haven't been especially reliable.  Use GitHub Actions to build both amd64 and arm64 containers for the main branch and for tags, and push them to Quay.  Continue building but not pushing containers on PR.  Requires the `QUAY_AUTH` repo secret to be set to a Docker credential.

Ideally we would cross-build the arm64 container by having the Dockerfile specify `FROM --platform=$BUILDPLATFORM` for the builder container and set `GOARCH=$TARGETARCH`.  However, Buildah < 1.24.1 doesn't support `--platform` in `FROM`.  Build in emulation for now, and skip arm64 in PRs to speed up CI.

Fixes https://github.com/coreos/butane/issues/324.  Alternative to #325.