### PR TITLE
config: add `flatcar` variant

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -70,6 +70,9 @@ var (
 	ErrUserNameSupport        = errors.New("users other than \"core\" are not supported in this spec version")
 	ErrKernelArgumentSupport  = errors.New("this field cannot be used for kernel arguments in this spec version; use openshift.kernel_arguments instead")
 
+	// Storage
+	ErrClevisSupport = errors.New("clevis is not supported in this spec version")
+
 	// Extensions
 	ErrExtensionNameRequired = errors.New("field \"name\" is required")
 )

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ import (
 	fcos1_4 "github.com/coreos/butane/config/fcos/v1_4"
 	fcos1_5_exp "github.com/coreos/butane/config/fcos/v1_5_exp"
 	flatcar1_0 "github.com/coreos/butane/config/flatcar/v1_0"
+	flatcar1_1_exp "github.com/coreos/butane/config/flatcar/v1_1_exp"
 	openshift4_10 "github.com/coreos/butane/config/openshift/v4_10"
 	openshift4_11_exp "github.com/coreos/butane/config/openshift/v4_11_exp"
 	openshift4_8 "github.com/coreos/butane/config/openshift/v4_8"
@@ -54,6 +55,7 @@ func init() {
 	RegisterTranslator("fcos", "1.4.0", fcos1_4.ToIgn3_3Bytes)
 	RegisterTranslator("fcos", "1.5.0-experimental", fcos1_5_exp.ToIgn3_4Bytes)
 	RegisterTranslator("flatcar", "1.0.0", flatcar1_0.ToIgn3_3Bytes)
+	RegisterTranslator("flatcar", "1.1.0-experimental", flatcar1_1_exp.ToIgn3_4Bytes)
 	RegisterTranslator("openshift", "4.8.0", openshift4_8.ToConfigBytes)
 	RegisterTranslator("openshift", "4.9.0", openshift4_9.ToConfigBytes)
 	RegisterTranslator("openshift", "4.10.0", openshift4_10.ToConfigBytes)

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 	fcos1_3 "github.com/coreos/butane/config/fcos/v1_3"
 	fcos1_4 "github.com/coreos/butane/config/fcos/v1_4"
 	fcos1_5_exp "github.com/coreos/butane/config/fcos/v1_5_exp"
+	flatcar1_0 "github.com/coreos/butane/config/flatcar/v1_0"
 	openshift4_10 "github.com/coreos/butane/config/openshift/v4_10"
 	openshift4_11_exp "github.com/coreos/butane/config/openshift/v4_11_exp"
 	openshift4_8 "github.com/coreos/butane/config/openshift/v4_8"
@@ -52,6 +53,7 @@ func init() {
 	RegisterTranslator("fcos", "1.3.0", fcos1_3.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.4.0", fcos1_4.ToIgn3_3Bytes)
 	RegisterTranslator("fcos", "1.5.0-experimental", fcos1_5_exp.ToIgn3_4Bytes)
+	RegisterTranslator("flatcar", "1.0.0", flatcar1_0.ToIgn3_3Bytes)
 	RegisterTranslator("openshift", "4.8.0", openshift4_8.ToConfigBytes)
 	RegisterTranslator("openshift", "4.9.0", openshift4_9.ToConfigBytes)
 	RegisterTranslator("openshift", "4.10.0", openshift4_10.ToConfigBytes)

--- a/config/flatcar/v1_0/schema.go
+++ b/config/flatcar/v1_0/schema.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_0
+
+import (
+	base "github.com/coreos/butane/base/v0_4"
+)
+
+type Config struct {
+	base.Config `yaml:",inline"`
+}

--- a/config/flatcar/v1_0/translate.go
+++ b/config/flatcar/v1_0/translate.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_0
+
+import (
+	"github.com/coreos/butane/config/common"
+	cutil "github.com/coreos/butane/config/util"
+	"github.com/coreos/butane/translate"
+
+	"github.com/coreos/ignition/v2/config/v3_3/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+// ToIgn3_3Unvalidated translates the config to an Ignition config.  It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	ret, ts, r := c.Config.ToIgn3_3Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
+
+	for i, luks := range ret.Storage.Luks {
+		if luks.Clevis.IsPresent() {
+			r.AddOnError(path.New("json", "storage", "luks", i, "clevis"), common.ErrClevisSupport)
+		}
+	}
+
+	return ret, ts, r
+}
+
+// ToIgn3_3 translates the config to an Ignition config.  It returns a
+// report of any errors or warnings in the source and resultant config.  If
+// the report has fatal errors or it encounters other problems translating,
+// an error is returned.
+func (c Config) ToIgn3_3(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_3Unvalidated", options)
+	return cfg.(types.Config), r, err
+}
+
+// ToIgn3_3Bytes translates from a v1.4 Butane config to a v3.3.0 Ignition config. It returns a report of any errors or
+// warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
+// translating, an error is returned.
+func ToIgn3_3Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_3", options)
+}

--- a/config/flatcar/v1_0/translate_test.go
+++ b/config/flatcar/v1_0/translate_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_0
+
+import (
+	"fmt"
+	"testing"
+
+	base "github.com/coreos/butane/base/v0_4"
+	"github.com/coreos/butane/config/common"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test translation of Flatcar support for Ignition config fields.
+func TestTranslation(t *testing.T) {
+	type entry struct {
+		kind report.EntryKind
+		err  error
+		path path.ContextPath
+	}
+	tests := []struct {
+		in      Config
+		entries []entry
+	}{
+		// all the warnings/errors
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Luks: []base.Luks{
+							{
+								Name:   "data",
+								Device: util.StrToPtr("/dev/disk/by-partlabel/USR-B"),
+							},
+							{
+								Name:   "data-bis",
+								Device: util.StrToPtr("/dev/disk/by-partlabel/USR-B-bis"),
+								Clevis: base.Clevis{Tpm2: util.BoolToPtr(true)},
+							},
+						},
+					},
+				},
+			},
+			[]entry{
+				{report.Error, common.ErrClevisSupport, path.New("json", "storage", "luks", 1, "clevis")},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.entries {
+				expectedReport.AddOn(entry.path, entry.err, entry.kind)
+			}
+			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
+	}
+}

--- a/config/flatcar/v1_1_exp/schema.go
+++ b/config/flatcar/v1_1_exp/schema.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1_exp
+
+import (
+	base "github.com/coreos/butane/base/v0_5_exp"
+)
+
+type Config struct {
+	base.Config `yaml:",inline"`
+}

--- a/config/flatcar/v1_1_exp/translate.go
+++ b/config/flatcar/v1_1_exp/translate.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1_exp
+
+import (
+	"github.com/coreos/butane/config/common"
+	cutil "github.com/coreos/butane/config/util"
+	"github.com/coreos/butane/translate"
+
+	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+// ToIgn3_4Unvalidated translates the config to an Ignition config.  It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	ret, ts, r := c.Config.ToIgn3_4Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
+
+	for i, luks := range ret.Storage.Luks {
+		if luks.Clevis.IsPresent() {
+			r.AddOnError(path.New("json", "storage", "luks", i, "clevis"), common.ErrClevisSupport)
+		}
+	}
+
+	return ret, ts, r
+}
+
+// ToIgn3_4 translates the config to an Ignition config.  It returns a
+// report of any errors or warnings in the source and resultant config.  If
+// the report has fatal errors or it encounters other problems translating,
+// an error is returned.
+func (c Config) ToIgn3_4(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_4Unvalidated", options)
+	return cfg.(types.Config), r, err
+}
+
+// ToIgn3_4Bytes translates from a v1.4 Butane config to a v3.3.0 Ignition config. It returns a report of any errors or
+// warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
+// translating, an error is returned.
+func ToIgn3_4Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_4", options)
+}

--- a/config/flatcar/v1_1_exp/translate_test.go
+++ b/config/flatcar/v1_1_exp/translate_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1_exp
+
+import (
+	"fmt"
+	"testing"
+
+	base "github.com/coreos/butane/base/v0_5_exp"
+	"github.com/coreos/butane/config/common"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test translation of Flatcar support for Ignition config fields.
+func TestTranslation(t *testing.T) {
+	type entry struct {
+		kind report.EntryKind
+		err  error
+		path path.ContextPath
+	}
+	tests := []struct {
+		in      Config
+		entries []entry
+	}{
+		// all the warnings/errors
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Luks: []base.Luks{
+							{
+								Name:   "data",
+								Device: util.StrToPtr("/dev/disk/by-partlabel/USR-B"),
+							},
+							{
+								Name:   "data-bis",
+								Device: util.StrToPtr("/dev/disk/by-partlabel/USR-B-bis"),
+								Clevis: base.Clevis{Tpm2: util.BoolToPtr(true)},
+							},
+						},
+					},
+				},
+			},
+			[]entry{
+				{report.Error, common.ErrClevisSupport, path.New("json", "storage", "luks", 1, "clevis")},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.entries {
+				expectedReport.AddOn(entry.path, entry.err, entry.kind)
+			}
+			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
+	}
+}

--- a/docs/config-flatcar-v1_0.md
+++ b/docs/config-flatcar-v1_0.md
@@ -1,0 +1,190 @@
+---
+title: Flatcar v1.0.0
+parent: Configuration specifications
+nav_order: 99
+---
+
+# Flatcar Specification v1.0.0
+
+The Flatcar configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+
+* **variant** (string): used to differentiate configs for different operating systems. Must be `flatcar` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.0.0` and generates Ignition configs with version `3.3.0`.
+* **_ignition_** (object): metadata about the configuration itself.
+  * **_config_** (objects): options related to the configuration.
+    * **_merge_** (list of objects): a list of the configs to be merged to the current config.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_replace_** (object): the config that will replace the current.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
+    * **_http_response_headers_** (integer) the time to wait (in seconds) for the server's response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.
+    * **_http_total_** (integer) the time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.
+  * **_security_** (object): options relating to network security.
+    * **_tls_** (object): options relating to TLS when fetching resources over `https`.
+      * **_certificate_authorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`, `inline`, or `local`.
+        * **_source_** (string): the URL of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+        * **_inline_** (string): the contents of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
+        * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
+        * **_compression_** (string): the type of compression used on the certificate (null or gzip). Compression cannot be used with S3.
+        * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+          * **name** (string): the header name.
+          * **_value_** (string): the header contents.
+        * **_verification_** (object): options related to the verification of the certificate.
+          * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
+    * **_http_proxy_** (string): will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by `https_proxy` or `no_proxy`.
+    * **_https_proxy_** (string): will be used as the proxy URL for HTTPS requests unless overridden by `no_proxy`.
+    * **_no_proxy_** (list of strings): specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an `IP address prefix (1.2.3.4)`, `an IP address prefix in CIDR notation (1.2.3.4/8)`, `a domain name`, or `a special DNS label (*)`. An IP address prefix and domain name can also include a literal port number `(1.2.3.4:80)`. A domain name matches that name and all subdomains. A domain name with a leading `.` matches subdomains only. For example `foo.com` matches `foo.com` and `bar.foo.com`; `.y.com` matches `x.y.com` but not `y.com`. A single asterisk `(*)` indicates that no proxying should be done.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_disks_** (list of objects): the list of disks to be configured and their options. Every entry must have a unique `device`.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
+    * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
+      * **_label_** (string): the PARTLABEL for the partition.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
+      * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
+      * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+      * **_guid_** (string): the GPT unique partition GUID.
+      * **_wipe_partition_entry_** (boolean) if true, Ignition will clobber an existing partition if it does not match the config. If false (default), Ignition will fail instead.
+      * **_should_exist_** (boolean) whether or not the partition with the specified `number` should exist. If omitted, it defaults to true. If false Ignition will either delete the specified partition or fail, depending on `wipePartitionEntry`. If false `number` must be specified and non-zero and `label`, `start`, `size`, `guid`, and `typeGuid` must all be omitted.
+      * **_resize_** (boolean) whether or not the existing partition should be resized. If omitted, it defaults to false. If true, Ignition will resize an existing partition if it matches the config in all respects except the partition size.
+  * **_raid_** (list of objects): the list of RAID arrays to be configured. Every RAID array must have a unique `name`.
+    * **name** (string): the name to use for the resulting md device.
+    * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
+    * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
+    * **_spares_** (integer): the number of spares (if applicable) in the array.
+    * **_options_** (list of strings): any additional options to be passed to mdadm.
+  * **_filesystems_** (list of objects): the list of filesystems to be configured. `device` and `format` need to be specified. Every filesystem must have a unique `device`.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, swap, or none).
+    * **_path_** (string): the mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
+    * **_wipe_filesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information. Defaults to false.
+    * **_label_** (string): the label of the filesystem.
+    * **_uuid_** (string): the uuid of the filesystem.
+    * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+    * **_mount_options_** (list of strings): any special options to be passed to the mount command.
+    * **_with_mount_unit_** (bool): whether to additionally generate a generic mount unit for this filesystem or a swap unit for this swap area. If a more specific unit is needed, a custom one can be specified in the `systemd.units` section. The unit will be named with the [escaped][systemd-escape] version of the `path` or `device`, depending on the unit type. If your filesystem is located on a Tang-backed LUKS device, the unit will automatically require network access if you specify the device as `/dev/mapper/<device-name>` or `/dev/disk/by-id/dm-name-<device-name>`.
+  * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
+    * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
+    * **_contents_** (object): options related to the contents of the file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents to append. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents to append, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the appended contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
+    * **_user_** (object): specifies the file's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
+    * **_mode_** (integer): the directory's permission mode. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path.
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
+    * **_user_** (object): specifies the symbolic link's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+    * **target** (string): the target path of the link
+    * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
+  * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
+    * **name** (string): the name of the luks device.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_key_file_** (string): options related to the contents of the key file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the key file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_label_** (string): the label of the luks device.
+    * **_uuid_** (string): the uuid of the luks device.
+    * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_wipe_volume_** (boolean): whether or not to wipe the device before volume creation, see [the Ignition documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.
+    * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
+    * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units. Every unit must have a unique `name`.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service").
+    * **_enabled_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit. Every drop-in must have a unique `name`.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
+    * **name** (string): the username for the account.
+    * **_password_hash_** (string): the hashed password for the account.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_home_dir_** (string): the home directory of the account.
+    * **_no_create_home_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primary_group_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_no_user_group_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_no_log_init_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_system_** (bool): whether or not this account should be a system account. This only has an effect if the account doesn't exist yet.
+  * **_groups_** (list of objects): the list of groups to be added. All groups must have a unique `name`.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_password_hash_** (string): the hashed password of the new group.
+    * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+* **_kernel_arguments_** (object): describes the desired kernel arguments.
+  * **_should_exist_** (list of strings): the list of kernel arguments that should exist.
+  * **_should_not_exist_** (list of strings): the list of kernel arguments that should not exist.
+
+[part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+[rfc2397]: https://tools.ietf.org/html/rfc2397
+[systemd-escape]: https://www.freedesktop.org/software/systemd/man/systemd-escape.html

--- a/docs/config-flatcar-v1_1-exp.md
+++ b/docs/config-flatcar-v1_1-exp.md
@@ -1,0 +1,192 @@
+---
+title: Flatcar v1.1.0-experimental
+parent: Configuration specifications
+nav_order: 100
+---
+
+# Flatcar Specification v1.1.0-experimental
+
+**Note: This configuration is experimental and has not been stabilized. It is subject to change without warning or announcement.**
+
+The Flatcar configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+
+* **variant** (string): used to differentiate configs for different operating systems. Must be `flatcar` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.1.0-experimental` and generates Ignition configs with version `3.4.0-experimental`.
+* **_ignition_** (object): metadata about the configuration itself.
+  * **_config_** (objects): options related to the configuration.
+    * **_merge_** (list of objects): a list of the configs to be merged to the current config.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_replace_** (object): the config that will replace the current.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
+    * **_http_response_headers_** (integer) the time to wait (in seconds) for the server's response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.
+    * **_http_total_** (integer) the time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.
+  * **_security_** (object): options relating to network security.
+    * **_tls_** (object): options relating to TLS when fetching resources over `https`.
+      * **_certificate_authorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`, `inline`, or `local`.
+        * **_source_** (string): the URL of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+        * **_inline_** (string): the contents of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
+        * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
+        * **_compression_** (string): the type of compression used on the certificate (null or gzip). Compression cannot be used with S3.
+        * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+          * **name** (string): the header name.
+          * **_value_** (string): the header contents.
+        * **_verification_** (object): options related to the verification of the certificate.
+          * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
+    * **_http_proxy_** (string): will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by `https_proxy` or `no_proxy`.
+    * **_https_proxy_** (string): will be used as the proxy URL for HTTPS requests unless overridden by `no_proxy`.
+    * **_no_proxy_** (list of strings): specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an `IP address prefix (1.2.3.4)`, `an IP address prefix in CIDR notation (1.2.3.4/8)`, `a domain name`, or `a special DNS label (*)`. An IP address prefix and domain name can also include a literal port number `(1.2.3.4:80)`. A domain name matches that name and all subdomains. A domain name with a leading `.` matches subdomains only. For example `foo.com` matches `foo.com` and `bar.foo.com`; `.y.com` matches `x.y.com` but not `y.com`. A single asterisk `(*)` indicates that no proxying should be done.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_disks_** (list of objects): the list of disks to be configured and their options. Every entry must have a unique `device`.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
+    * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
+      * **_label_** (string): the PARTLABEL for the partition.
+      * **_number_** (integer): the partition number, which dictates its position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
+      * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
+      * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+      * **_guid_** (string): the GPT unique partition GUID.
+      * **_wipe_partition_entry_** (boolean) if true, Ignition will clobber an existing partition if it does not match the config. If false (default), Ignition will fail instead.
+      * **_should_exist_** (boolean) whether or not the partition with the specified `number` should exist. If omitted, it defaults to true. If false Ignition will either delete the specified partition or fail, depending on `wipePartitionEntry`. If false `number` must be specified and non-zero and `label`, `start`, `size`, `guid`, and `typeGuid` must all be omitted.
+      * **_resize_** (boolean) whether or not the existing partition should be resized. If omitted, it defaults to false. If true, Ignition will resize an existing partition if it matches the config in all respects except the partition size.
+  * **_raid_** (list of objects): the list of RAID arrays to be configured. Every RAID array must have a unique `name`.
+    * **name** (string): the name to use for the resulting md device.
+    * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
+    * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
+    * **_spares_** (integer): the number of spares (if applicable) in the array.
+    * **_options_** (list of strings): any additional options to be passed to mdadm.
+  * **_filesystems_** (list of objects): the list of filesystems to be configured. `device` and `format` need to be specified. Every filesystem must have a unique `device`.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, swap, or none).
+    * **_path_** (string): the mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
+    * **_wipe_filesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information. Defaults to false.
+    * **_label_** (string): the label of the filesystem.
+    * **_uuid_** (string): the uuid of the filesystem.
+    * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+    * **_mount_options_** (list of strings): any special options to be passed to the mount command.
+    * **_with_mount_unit_** (bool): whether to additionally generate a generic mount unit for this filesystem or a swap unit for this swap area. If a more specific unit is needed, a custom one can be specified in the `systemd.units` section. The unit will be named with the [escaped][systemd-escape] version of the `path` or `device`, depending on the unit type. If your filesystem is located on a Tang-backed LUKS device, the unit will automatically require network access if you specify the device as `/dev/mapper/<device-name>` or `/dev/disk/by-id/dm-name-<device-name>`.
+  * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
+    * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
+    * **_contents_** (object): options related to the contents of the file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents to append. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents to append, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the appended contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
+    * **_user_** (object): specifies the file's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
+    * **_mode_** (integer): the directory's permission mode. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path.
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
+    * **_user_** (object): specifies the symbolic link's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+    * **target** (string): the target path of the link
+    * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
+  * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
+    * **name** (string): the name of the luks device.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_key_file_** (string): options related to the contents of the key file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the key file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_label_** (string): the label of the luks device.
+    * **_uuid_** (string): the uuid of the luks device.
+    * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_wipe_volume_** (boolean): whether or not to wipe the device before volume creation, see [the Ignition documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.
+    * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
+    * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units. Every unit must have a unique `name`.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service").
+    * **_enabled_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit. Every drop-in must have a unique `name`.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
+    * **name** (string): the username for the account.
+    * **_password_hash_** (string): the hashed password for the account.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_home_dir_** (string): the home directory of the account.
+    * **_no_create_home_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primary_group_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_no_user_group_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_no_log_init_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_system_** (bool): whether or not this account should be a system account. This only has an effect if the account doesn't exist yet.
+  * **_groups_** (list of objects): the list of groups to be added. All groups must have a unique `name`.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_password_hash_** (string): the hashed password of the new group.
+    * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+* **_kernel_arguments_** (object): describes the desired kernel arguments.
+  * **_should_exist_** (list of strings): the list of kernel arguments that should exist.
+  * **_should_not_exist_** (list of strings): the list of kernel arguments that should not exist.
+
+[part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+[rfc2397]: https://tools.ietf.org/html/rfc2397
+[systemd-escape]: https://www.freedesktop.org/software/systemd/man/systemd-escape.html

--- a/docs/config-openshift-v4_10.md
+++ b/docs/config-openshift-v4_10.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift v4.10.0
 parent: Configuration specifications
-nav_order: 96
+nav_order: 146
 ---
 
 # OpenShift Specification v4.10.0

--- a/docs/config-openshift-v4_11-exp.md
+++ b/docs/config-openshift-v4_11-exp.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift v4.11.0-experimental
 parent: Configuration specifications
-nav_order: 100
+nav_order: 150
 ---
 
 # OpenShift Specification v4.11.0-experimental

--- a/docs/config-openshift-v4_8.md
+++ b/docs/config-openshift-v4_8.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift v4.8.0
 parent: Configuration specifications
-nav_order: 98
+nav_order: 148
 ---
 
 # OpenShift Specification v4.8.0

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift v4.9.0
 parent: Configuration specifications
-nav_order: 97
+nav_order: 147
 ---
 
 # OpenShift Specification v4.9.0

--- a/docs/config-rhcos-v0_1.md
+++ b/docs/config-rhcos-v0_1.md
@@ -1,7 +1,7 @@
 ---
 title: RHEL CoreOS v0.1.0
 parent: Configuration specifications
-nav_order: 99
+nav_order: 149
 ---
 
 # RHEL CoreOS Specification v0.1.0

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -20,6 +20,8 @@ We recommend that you always use the latest **stable** specification for your op
   - [v1.2.0](config-fcos-v1_2.md)
   - [v1.1.0](config-fcos-v1_1.md)
   - [v1.0.0](config-fcos-v1_0.md)
+- Flatcar (`flatcar`)
+  - [v1.0.0](config-flatcar-v1_0.md)
 - OpenShift (`openshift`)
   - [v4.10.0](config-openshift-v4_10.md)
   - [v4.9.0](config-openshift-v4_9.md)
@@ -53,6 +55,7 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `fcos`         | 1.3.0               | 3.2.0              |
 | `fcos`         | 1.4.0               | 3.3.0              |
 | `fcos`         | 1.5.0-experimental  | 3.4.0-experimental |
+| `flatcar`      | 1.0.0               | 3.3.0              |
 | `openshift`    | 4.8.0               | 3.2.0              |
 | `openshift`    | 4.9.0               | 3.2.0              |
 | `openshift`    | 4.10.0              | 3.2.0              |

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -33,6 +33,8 @@ Do not use **experimental** specifications for anything beyond **development and
 
 - Fedora CoreOS (`fcos`)
   - [v1.5.0-experimental](config-fcos-v1_5-exp.md)
+- Flatcar (`flatcar`)
+  - [v1.1.0-experimental](config-flatcar-v1_1-exp.md)
 - OpenShift (`openshift`)
   - [v4.11.0-experimental](config-openshift-v4_11-exp.md)
 
@@ -56,6 +58,7 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `fcos`         | 1.4.0               | 3.3.0              |
 | `fcos`         | 1.5.0-experimental  | 3.4.0-experimental |
 | `flatcar`      | 1.0.0               | 3.3.0              |
+| `flatcar`      | 1.1.0-experimental  | 3.4.0-experimental |
 | `openshift`    | 4.8.0               | 3.2.0              |
 | `openshift`    | 4.9.0               | 3.2.0              |
 | `openshift`    | 4.10.0              | 3.2.0              |


### PR DESCRIPTION
Hi,

With the latest Alpha release of Flatcar (3185.0.0), Ignition version has been updated to 2.13.0. Besides Ignition v1 and v2 configurations, Ignition configurations with specification v3 (up to 3.3.0) are now supported.

This PR brings a `flatcar` butane variant to generate Ignition spec to version `3.3.0`.