### PR TITLE
Dockerfile: Use a full base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ COPY . /butane
 WORKDIR /butane
 RUN ./build_for_container
 
-FROM scratch
+FROM registry.fedoraproject.org/fedora-minimal:35
 COPY --from=builder /butane/bin/container/butane /usr/local/bin/butane
 ENTRYPOINT ["/usr/local/bin/butane"]


### PR DESCRIPTION
I'm trying to use butane in a `Dockerfile` as part of a multi-stage
build, and not having anything except the binary in the container
breaks that since `Dockerfile` wants to invoke things via `/bin/sh`.

Use ubi8 as a base.