### PR TITLE
config/openshift: reject file modes with special bits set

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -64,6 +64,7 @@ var (
 	ErrFileSchemeSupport      = errors.New("file contents source must be data URL in this spec version")
 	ErrFileAppendSupport      = errors.New("appending to files is not supported in this spec version")
 	ErrFileCompressionSupport = errors.New("file compression is not supported in this spec version")
+	ErrFileSpecialModeSupport = errors.New("special mode bits are not supported in this spec version")
 	ErrLinkSupport            = errors.New("links are not supported in this spec version")
 	ErrGroupSupport           = errors.New("groups are not supported in this spec version")
 	ErrUserFieldSupport       = errors.New("fields other than \"name\" and \"ssh_authorized_keys\" are not supported in this spec version")

--- a/config/openshift/v4_10/translate_test.go
+++ b/config/openshift/v4_10/translate_test.go
@@ -386,6 +386,7 @@ func TestValidateSupport(t *testing.T) {
 									Contents: base.Resource{
 										Source: util.StrToPtr("https://example.com/"),
 									},
+									Mode: util.IntToPtr(04755),
 								},
 							},
 							Filesystems: []base.Filesystem{
@@ -444,6 +445,7 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
 				{report.Error, common.ErrFileSchemeSupport, path.New("yaml", "storage", "files", 2, "contents", "source")},
+				{report.Error, common.ErrFileSpecialModeSupport, path.New("yaml", "storage", "files", 2, "mode")},
 				{report.Error, common.ErrLinkSupport, path.New("yaml", "storage", "links", 0)},
 				{report.Error, common.ErrGroupSupport, path.New("yaml", "passwd", "groups", 0)},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "gecos")},

--- a/config/openshift/v4_10/validate_test.go
+++ b/config/openshift/v4_10/validate_test.go
@@ -153,7 +153,7 @@ func TestReportCorrelation(t *testing.T) {
                          storage:
                            files:
                            - path: /z
-                             mode: 644`,
+                             mode: 444`,
 			common.ErrDecimalMode.Error(),
 			9,
 		},

--- a/config/openshift/v4_11_exp/translate.go
+++ b/config/openshift/v4_11_exp/translate.go
@@ -245,6 +245,10 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 				r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "contents", "source"), common.ErrFileSchemeSupport)
 			}
 		}
+		if file.Mode != nil && *file.Mode & ^0777 != 0 {
+			// UNPARSABLE
+			r.AddOnError(path.New("json", "spec", "config", "storage", "files", i, "mode"), common.ErrFileSpecialModeSupport)
+		}
 	}
 	for i := range mc.Spec.Config.Storage.Links {
 		// IMMUTABLE

--- a/config/openshift/v4_11_exp/translate_test.go
+++ b/config/openshift/v4_11_exp/translate_test.go
@@ -386,6 +386,7 @@ func TestValidateSupport(t *testing.T) {
 									Contents: base.Resource{
 										Source: util.StrToPtr("https://example.com/"),
 									},
+									Mode: util.IntToPtr(04755),
 								},
 							},
 							Filesystems: []base.Filesystem{
@@ -457,6 +458,7 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrDirectorySupport, path.New("yaml", "storage", "directories", 0)},
 				{report.Error, common.ErrFileAppendSupport, path.New("yaml", "storage", "files", 1, "append")},
 				{report.Error, common.ErrFileSchemeSupport, path.New("yaml", "storage", "files", 2, "contents", "source")},
+				{report.Error, common.ErrFileSpecialModeSupport, path.New("yaml", "storage", "files", 2, "mode")},
 				{report.Error, common.ErrLinkSupport, path.New("yaml", "storage", "links", 0)},
 				{report.Error, common.ErrGroupSupport, path.New("yaml", "passwd", "groups", 0)},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "gecos")},

--- a/config/openshift/v4_11_exp/validate_test.go
+++ b/config/openshift/v4_11_exp/validate_test.go
@@ -153,7 +153,7 @@ func TestReportCorrelation(t *testing.T) {
                          storage:
                            files:
                            - path: /z
-                             mode: 644`,
+                             mode: 444`,
 			common.ErrDecimalMode.Error(),
 			9,
 		},


### PR DESCRIPTION
MCO 4.10+ rejects file modes larger than 0777.  Add a validation to do that too.  In versions older than 4.10, both Ignition and the MCO ignore special mode bits, so we also continue doing so to avoid breaking previously-working configs.  (There's nothing preventing users from using an older Butane spec with a newer OpenShift, but the missed validation in that case seems reasonable to avoid the breaking change.)

Change the `ErrDecimalMode` test to avoid accidentally triggering `ErrFileSpecialModeSupport` as well.