### PR TITLE
translate: add `TranslationSet.Map()` to further translate `To` fields

### DIFF
--- a/translate/set.go
+++ b/translate/set.go
@@ -160,6 +160,24 @@ OUTER:
 	return ret
 }
 
+// Map returns a new TranslationSet with To translation paths further
+// translated through mappings.  Translations not listed in mappings are
+// copied unmodified.
+func (ts TranslationSet) Map(mappings TranslationSet) TranslationSet {
+	if mappings.FromTag != ts.ToTag || mappings.ToTag != ts.ToTag {
+		panic(fmt.Sprintf("mappings have incorrect tag; %q != %q || %q != %q", mappings.FromTag, ts.ToTag, mappings.ToTag, ts.ToTag))
+	}
+	ret := NewTranslationSet(ts.FromTag, ts.ToTag)
+	ret.Merge(ts)
+	for _, mapping := range mappings.Set {
+		if t, ok := ret.Set[mapping.From.String()]; ok {
+			delete(ret.Set, mapping.From.String())
+			ret.AddTranslation(t.From, mapping.To)
+		}
+	}
+	return ret
+}
+
 // DebugVerifyCoverage recursively checks whether every non-zero field in v
 // has a translation.  If translations are missing, it returns a multi-line
 // error listing them.

--- a/translate/set_test.go
+++ b/translate/set_test.go
@@ -1,0 +1,60 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslationSetMap(t *testing.T) {
+	create := func() TranslationSet {
+		return mkTrans(
+			fp(), fp(),
+			fp("a"), fp("A"),
+			fp("a", 0), fp("A", 0),
+			fp("a", 0, "b"), fp("A", 0, "B"),
+			fp("a", 0, "b", "c"), fp("A", 0, "B"),
+			fp("a", 0, "b", "d"), fp("A", 0, "B", 0),
+			fp("a", 0, "b", "e"), fp("A", 0, "B", 0, "C"),
+			fp("a", 0, "b", "f"), fp("A", 0, "B", 0, "D"),
+			fp("clobbered"), fp("A", 0, "B", 0, "G"),
+			fp("a", 0, "b", "g"), fp("A", 0, "B", 1),
+			fp("a", 0, "b", "h"), fp("A", 0, "B", 1, "E"),
+			fp("a", 0, "b", "i"), fp("A", 0, "B", 1, "F"),
+		)
+	}
+	ts := create()
+	result := ts.Map(mkTrans(
+		fp("A", 0, "B", 0, "C"), fp("A", 0, "B", 0, "G"),
+		fp("A", 0, "B", 0, "D"), fp("A", 0, "H"),
+		fp("missing"), fp("B"),
+	))
+	assert.Equal(t, create(), ts, "original was changed")
+	assert.Equal(t, mkTrans(
+		fp(), fp(),
+		fp("a"), fp("A"),
+		fp("a", 0), fp("A", 0),
+		fp("a", 0, "b"), fp("A", 0, "B"),
+		fp("a", 0, "b", "c"), fp("A", 0, "B"),
+		fp("a", 0, "b", "d"), fp("A", 0, "B", 0),
+		fp("a", 0, "b", "e"), fp("A", 0, "B", 0, "G"),
+		fp("a", 0, "b", "f"), fp("A", 0, "H"),
+		fp("a", 0, "b", "g"), fp("A", 0, "B", 1),
+		fp("a", 0, "b", "h"), fp("A", 0, "B", 1, "E"),
+		fp("a", 0, "b", "i"), fp("A", 0, "B", 1, "F"),
+	), result, "bad mapping")
+}

--- a/translate/set_test.go
+++ b/translate/set_test.go
@@ -17,8 +17,28 @@ package translate
 import (
 	"testing"
 
+	"github.com/coreos/vcontext/path"
 	"github.com/stretchr/testify/assert"
 )
+
+// mkTrans makes a TranslationSet with no tag in the paths consuming pairs of args. i.e:
+// mkTrans(from1, to1, from2, to2) -> a set wiht from1->to1, from2->to2
+// This is just a shorthand for making writing tests easier
+func mkTrans(paths ...path.ContextPath) TranslationSet {
+	ret := TranslationSet{Set: map[string]Translation{}}
+	if len(paths)%2 == 1 {
+		panic("Odd number of args to mkTrans")
+	}
+	for i := 0; i < len(paths); i += 2 {
+		ret.AddTranslation(paths[i], paths[i+1])
+	}
+	return ret
+}
+
+// fp means "fastpath"; super shorthand, we'll use it a lot
+func fp(parts ...interface{}) path.ContextPath {
+	return path.New("", parts...)
+}
 
 func TestTranslationSetMap(t *testing.T) {
 	create := func() TranslationSet {

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/coreos/butane/translate/tests/pkga"
 	"github.com/coreos/butane/translate/tests/pkgb"
 
-	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,25 +28,6 @@ import (
 type testOptions struct{}
 
 // Note: we need different input and output types which unfortunately means a lot of tests
-
-// mkTrans makes a TranslationSet with no tag in the paths consuming pairs of args. i.e:
-// mkTrans(from1, to1, from2, to2) -> a set wiht from1->to1, from2->to2
-// This is just a shorthand for making writing tests easier
-func mkTrans(paths ...path.ContextPath) TranslationSet {
-	ret := TranslationSet{Set: map[string]Translation{}}
-	if len(paths)%2 == 1 {
-		panic("Odd number of args to mkTrans")
-	}
-	for i := 0; i < len(paths); i += 2 {
-		ret.AddTranslation(paths[i], paths[i+1])
-	}
-	return ret
-}
-
-// fp means "fastpath"; super shorthand, we'll use it a lot
-func fp(parts ...interface{}) path.ContextPath {
-	return path.New("", parts...)
-}
 
 func TestTranslateTrivial(t *testing.T) {
 	in := pkga.Trivial{


### PR DESCRIPTION
In special circumstances, postprocessing code may need to rearrange fields already translated to output space, in which case it needs to update the corresponding translations.  Provide a helper function to do so.

For https://github.com/coreos/butane/pull/339.