### PR TITLE
translate: use `FromTag` in `From` paths added by `AddFromCommonSource`

### DIFF
--- a/translate/set.go
+++ b/translate/set.go
@@ -113,7 +113,7 @@ func (ts TranslationSet) AddFromCommonObject(fromPrefix path.ContextPath, toPref
 	vPaths := getAllPaths(vTo, ts.ToTag, true)
 
 	for _, path := range vPaths {
-		ts.AddTranslation(prefixPath(path, fromPrefix.Path...), prefixPath(path, toPrefix.Path...))
+		ts.AddTranslation(fromPrefix.Append(path.Path...), toPrefix.Append(path.Path...))
 	}
 	ts.AddTranslation(fromPrefix, toPrefix)
 }

--- a/translate/set_test.go
+++ b/translate/set_test.go
@@ -78,3 +78,23 @@ func TestTranslationSetMap(t *testing.T) {
 		fp("a", 0, "b", "i"), fp("A", 0, "B", 1, "F"),
 	), result, "bad mapping")
 }
+
+func TestTranslationSetAddFromCommonSource(t *testing.T) {
+	type Sub struct {
+		C int `json:"c"`
+	}
+	type Main struct {
+		A string `json:"a"`
+		B Sub    `json:"b"`
+	}
+
+	expected := NewTranslationSet("yaml", "json")
+	expected.AddTranslation(path.New("yaml", "y"), path.New("json", "z", 0))
+	expected.AddTranslation(path.New("yaml", "y", "a"), path.New("json", "z", 0, "a"))
+	expected.AddTranslation(path.New("yaml", "y", "b"), path.New("json", "z", 0, "b"))
+	expected.AddTranslation(path.New("yaml", "y", "b", "c"), path.New("json", "z", 0, "b", "c"))
+
+	actual := NewTranslationSet("yaml", "json")
+	actual.AddFromCommonObject(path.New("yaml", "y"), path.New("json", "z", 0), &Main{})
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
`AddFromCommonSource` was using the `ToTag` in both paths.  Use the `FromTag` in the `From` path, and add a test.

Followup to #339.