### PR TITLE
test: make test script universally executable

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,10 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Check out repository
       uses: actions/checkout@v3
+    - name: Install GNU utils on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install coreutils
     - name: Run tests
       shell: bash
       run: ./test

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,10 @@ nav_order: 9
 
 ### Misc. changes
 
+- The `test` script now executes all tests on all platforms if the necessary GNU
+  utilities are available
+- CI jobs now include macOS specific instructions to install GNU utilities for
+  improved test coverage
 
 ### Docs changes
 

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SRC=$(find . -name '*.go' -not -path "./vendor/*")
@@ -21,7 +21,29 @@ source ./build
 echo "Running tests"
 go test ./... -cover
 
+csplit=""
+head=""
+
 if [ "$(go env GOOS)" = linux ]; then
+    csplit="csplit"
+    head="head"
+elif [ "$(go env GOOS)" = darwin ]; then
+    # macOS has BSD versions of csplit and head that behave differently;
+    # check whether brew/macports supplied GNU versions exist
+    if hash gcsplit &> /dev/null; then
+        csplit="gcsplit"
+    fi
+    if hash ghead &> /dev/null; then
+        head="ghead"
+    fi
+elif [ "$(go env GOOS)" = windows ]; then
+    # if we find a Bash on Windows we can comparatively safely assume
+    # Git Bash with GNU utils is being used
+    csplit="csplit"
+    head="head"
+fi
+
+if [ -n "${csplit}" ] && [ -n "${head}" ]; then
     echo "Checking docs"
     shopt -s nullglob
     mkdir tmpdocs
@@ -32,23 +54,23 @@ if [ "$(go env GOOS)" = linux ]; then
 
     for doc in docs/*md
     do
-            echo "Checking $doc"
+            echo "Checking ${doc}"
             # split each doc into a bunch of tmpfiles then run butane on them
-            sed -n '/^<!-- butane-config -->/,/^```$/ p' < ${doc} \
-                    | csplit - '/<!-- butane-config -->/' '{*}' -z --prefix "tmpdocs/config_$(basename ${doc%.*})_" -q
+            sed -n '/^<!-- butane-config -->/,/^```$/ p' < "${doc}" \
+                    | ${csplit} - '/<!-- butane-config -->/' '{*}' -z --prefix "tmpdocs/config_$(basename ${doc%.*})_" -q
 
             for i in tmpdocs/config_*
             do
-                    echo "Checking $i"
-                    cat "$i" | tail -n +3 | head -n -1 \
-                            | ${BIN_PATH}/${NAME} --strict --files-dir tmpdocs/files-dir > /dev/null \
-                            || (cat -n "$i" && false)
+                    echo "Checking ${i}"
+                    tail -n +3 "${i}" | ${head} -n -1 \
+                            | "${BIN_PATH}/${NAME}" --strict --files-dir tmpdocs/files-dir > /dev/null \
+                            || (cat -n "${i}" && false)
             done
             rm -f tmpdocs/config_*
     done
 else
-    # Avoid dealing with presence/behavior of csplit
-    echo "skipping docs check on non-Linux"
+    # Avoid dealing with presence/behavior of csplit and head
+    echo "skipping docs check because GNU csplit and head are unavailable"
 fi
 
 echo ok

--- a/test
+++ b/test
@@ -54,19 +54,19 @@ if [ -n "${csplit}" ] && [ -n "${head}" ]; then
 
     for doc in docs/*md
     do
-            echo "Checking ${doc}"
-            # split each doc into a bunch of tmpfiles then run butane on them
-            sed -n '/^<!-- butane-config -->/,/^```$/ p' < "${doc}" \
-                    | ${csplit} - '/<!-- butane-config -->/' '{*}' -z --prefix "tmpdocs/config_$(basename ${doc%.*})_" -q
+        echo "Checking ${doc}"
+        # split each doc into a bunch of tmpfiles then run butane on them
+        sed -n '/^<!-- butane-config -->/,/^```$/ p' <"${doc}" \
+             | ${csplit} - '/<!-- butane-config -->/' '{*}' -z --prefix "tmpdocs/config_$(basename ${doc%.*})_" -q
 
-            for i in tmpdocs/config_*
-            do
-                    echo "Checking ${i}"
-                    tail -n +3 "${i}" | ${head} -n -1 \
-                            | "${BIN_PATH}/${NAME}" --strict --files-dir tmpdocs/files-dir > /dev/null \
-                            || (cat -n "${i}" && false)
-            done
-            rm -f tmpdocs/config_*
+        for i in tmpdocs/config_*
+        do
+            echo "Checking ${i}"
+            tail -n +3 "${i}" | ${head} -n -1 \
+                | "${BIN_PATH}/${NAME}" --strict --files-dir tmpdocs/files-dir >/dev/null \
+                || (cat -n "${i}" && false)
+        done
+        rm -f tmpdocs/config_*
     done
 else
     # Avoid dealing with presence/behavior of csplit and head


### PR DESCRIPTION
Currently, the `test` script is not universally executable/skips large parts on non-Linux environments. With very few assumptions we can make it reasonably compatible with macOS and Windows (or at least offer a way for contributors to understand what they need to do to run it on those platforms successfully).

- use user supplied bash (e.g. modern, user installed Bash versions on macOS)
- skip doc checks only if necessary GNU utils aren't found
  - macOS may have them prefixed with `g` (installed via Homebrew or MacPorts)
  - Windows capable of running Bash scripts is most likely using Git Bash with
    built in GNU utils such as csplit and head
- align formatting (4 vs. 8 spaces)
- prevent accidental word-splitting by quoting variables
- use shell redirects instead of `cat`

This is part of the effort to make #289 better reviewable as discussed in the comments there.