### PR TITLE
Add draft release notes for next release

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,9 @@ nav_order: 9
 
 ## Butane 0.15.0 (2022-06-23)
 
+Starting with this release, Butane binaries are signed with the [Fedora 36
+key](https://getfedora.org/security/).
+
 ### Breaking changes
 
 - Return selected `compression` field value from `MakeDataURL()` _(Go API)_
@@ -47,6 +50,9 @@ nav_order: 9
 
 
 ## Butane 0.14.0 (2022-01-27)
+
+Starting with this release, Butane binaries are signed with the [Fedora 35
+key](https://getfedora.org/security/).
 
 ### Breaking changes
 
@@ -144,6 +150,9 @@ nav_order: 9
 
 ## Butane 0.12.0 (2021-06-08)
 
+Starting with this release, Butane binaries are signed with the [Fedora 34
+key](https://getfedora.org/security/).
+
 ### Features
 
 - Add `kernel_arguments` section _(fcos 1.4.0-exp, openshift 4.9.0-exp)_
@@ -222,6 +231,9 @@ nav_order: 9
 
 ## FCCT 0.8.0 (2020-12-04)
 
+Starting with this release, Butane binaries are signed with the [Fedora 33
+key](https://getfedora.org/security/).
+
 ### Breaking changes
 
 - Restructure Go API
@@ -275,6 +287,9 @@ nav_order: 9
 
 
 ## FCCT 0.6.0 (2020-05-28)
+
+Starting with this release, Butane binaries are signed with the [Fedora 32
+key](https://getfedora.org/security/).
 
 ### Features
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,26 @@ nav_order: 9
 
 # Release notes
 
+## Upcoming Butane 0.16.0 (unreleased)
+
+### Breaking changes
+
+
+### Features
+
+- Ship aarch64 macOS binary in GitHub release artifacts
+
+### Bug fixes
+
+
+### Misc. changes
+
+
+### Docs changes
+
+
+
+
 ## Butane 0.15.0 (2022-06-23)
 
 Starting with this release, Butane binaries are signed with the [Fedora 36


### PR DESCRIPTION
We're going to try maintaining these incrementally as we work toward the next release, rather than building them from scratch at release time.

Also, backfill notes of historical signing key changes (xref https://github.com/coreos/repo-templates/pull/10).