### PR TITLE
Bump minimum Go version to 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test build
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.17.x, 1.18.x]
         os: [ubuntu-latest]
         include:
         - go-version: 1.18.x

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/butane
 
-go 1.15
+go 1.17
 
 require (
 	github.com/clarketm/json v1.14.1

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,14 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.8.0
 	github.com/vincent-petithory/dataurl v1.0.0
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/aws/aws-sdk-go v1.30.28 // indirect
+	github.com/coreos/go-json v0.0.0-20211020211907-c63f628265de // indirect
+	github.com/coreos/go-systemd/v22 v22.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/vendor/github.com/coreos/go-json/go.mod
+++ b/vendor/github.com/coreos/go-json/go.mod
@@ -1,3 +1,0 @@
-module github.com/coreos/go-json
-
-go 1.15

--- a/vendor/github.com/spf13/pflag/go.mod
+++ b/vendor/github.com/spf13/pflag/go.mod
@@ -1,3 +1,0 @@
-module github.com/spf13/pflag
-
-go 1.12

--- a/vendor/gopkg.in/yaml.v3/go.mod
+++ b/vendor/gopkg.in/yaml.v3/go.mod
@@ -1,5 +1,0 @@
-module "gopkg.in/yaml.v3"
-
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,9 +1,11 @@
 # github.com/aws/aws-sdk-go v1.30.28
+## explicit; go 1.11
 github.com/aws/aws-sdk-go/aws/arn
 # github.com/clarketm/json v1.14.1
 ## explicit
 github.com/clarketm/json
 # github.com/coreos/go-json v0.0.0-20211020211907-c63f628265de
+## explicit; go 1.15
 github.com/coreos/go-json
 # github.com/coreos/go-semver v0.3.0
 ## explicit
@@ -12,9 +14,10 @@ github.com/coreos/go-semver/semver
 ## explicit
 github.com/coreos/go-systemd/unit
 # github.com/coreos/go-systemd/v22 v22.0.0
+## explicit; go 1.12
 github.com/coreos/go-systemd/v22/unit
 # github.com/coreos/ignition/v2 v2.14.0
-## explicit
+## explicit; go 1.15
 github.com/coreos/ignition/v2/config/merge
 github.com/coreos/ignition/v2/config/shared/errors
 github.com/coreos/ignition/v2/config/shared/validations
@@ -26,7 +29,7 @@ github.com/coreos/ignition/v2/config/v3_3/types
 github.com/coreos/ignition/v2/config/v3_4_experimental/types
 github.com/coreos/ignition/v2/config/validate
 # github.com/coreos/vcontext v0.0.0-20220603180515-2076d8d16945
-## explicit
+## explicit; go 1.15
 github.com/coreos/vcontext/json
 github.com/coreos/vcontext/path
 github.com/coreos/vcontext/report
@@ -34,14 +37,16 @@ github.com/coreos/vcontext/tree
 github.com/coreos/vcontext/validate
 github.com/coreos/vcontext/yaml
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/pmezard/go-difflib v1.0.0
+## explicit
 github.com/pmezard/go-difflib/difflib
 # github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
-## explicit
+## explicit; go 1.12
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.8.0
-## explicit
+## explicit; go 1.13
 github.com/stretchr/testify/assert
 # github.com/vincent-petithory/dataurl v1.0.0
 ## explicit


### PR DESCRIPTION
Go 1.15 and 1.16 are EOL.