### PR TITLE
fcos translate.go: add warn on small or constrained root partition

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -68,6 +68,8 @@ var (
 	// partition
 	ErrReuseByLabel         = errors.New("partitions cannot be reused by label; number must be specified except on boot disk (/dev/disk/by-id/coreos-boot-disk) or when wipe_table is true")
 	ErrWrongPartitionNumber = errors.New("incorrect partition number; a new partition will be created using reserved label")
+	ErrRootTooSmall         = errors.New("root should have 8GiB of space assigned")
+	ErrRootConstrained      = errors.New("root partition cannot expand; it is set to fill available space but is followed by an auto-positioned partition")
 
 	// MachineConfigs
 	ErrFieldElided              = errors.New("field ignored in raw mode")

--- a/config/fcos/v1_3/translate.go
+++ b/config/fcos/v1_3/translate.go
@@ -70,16 +70,34 @@ func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Conf
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	for i, disk := range ret.Storage.Disks {
-		// In the boot_device.mirror case, nothing specifies partition numbers
-		// so match existing partitions only when `wipeTable` is false
-		if !util.IsTrue(disk.WipeTable) {
-			for j, partition := range disk.Partitions {
-				// check for reserved partlabels
-				if partition.Label != nil {
-					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
-						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+		for p, partition := range disk.Partitions {
+			// check for root partition size constraints
+			if partition.Label != nil {
+				if *partition.Label == "root" {
+					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
+						for idx := range disk.Partitions {
+							if idx == p {
+								continue
+							}
+							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
+								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
+								break
+							}
+						}
+					} else if *partition.SizeMiB < 8192 {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "size_mib"), common.ErrRootTooSmall)
 					}
 				}
+
+				// In the boot_device.mirror case, nothing specifies partition numbers
+				// so match existing partitions only when `wipeTable` is false
+				if !util.IsTrue(disk.WipeTable) {
+					// check for reserved partlabels
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+
 			}
 		}
 	}

--- a/config/fcos/v1_3/translate_test.go
+++ b/config/fcos/v1_3/translate_test.go
@@ -1423,3 +1423,242 @@ func TestTranslateBootDevice(t *testing.T) {
 		})
 	}
 }
+
+func TestRootPartitionConstraints(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     Config
+		report report.Report
+	}{
+		{
+			name: "root constrained by auto-positioned partition",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(0), // fill available
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - will be placed after root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root constrained by auto-positioned partition with explicit root start",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		// Root partition NOT constrained because next partition has explicit StartMiB
+		{
+			name: "root not constrained with explicit StartMiB after",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position - does NOT constrain root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		// Root partition constrained by auto-positioned partition even when
+		// an explicit partition is also present
+		{
+			name: "root constrained by auto-positioned partition with explicit also present",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition too small",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(4096),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootTooSmall.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "size_mib"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition exactly 8GiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		{
+			name: "root constrained with nil sizeMiB and nil startMiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+									{
+										Label: util.StrToPtr("data"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			r = confutil.TranslateReportPaths(r, translations)
+			assert.Equal(t, test.report, r, "report mismatch")
+		})
+	}
+}

--- a/config/fcos/v1_4/translate.go
+++ b/config/fcos/v1_4/translate.go
@@ -70,16 +70,34 @@ func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Conf
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	for i, disk := range ret.Storage.Disks {
-		// In the boot_device.mirror case, nothing specifies partition numbers
-		// so match existing partitions only when `wipeTable` is false
-		if !util.IsTrue(disk.WipeTable) {
-			for j, partition := range disk.Partitions {
-				// check for reserved partlabels
-				if partition.Label != nil {
-					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
-						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+		for p, partition := range disk.Partitions {
+			// check for root partition size constraints
+			if partition.Label != nil {
+				if *partition.Label == "root" {
+					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
+						for idx := range disk.Partitions {
+							if idx == p {
+								continue
+							}
+							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
+								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
+								break
+							}
+						}
+					} else if *partition.SizeMiB < 8192 {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "size_mib"), common.ErrRootTooSmall)
 					}
 				}
+
+				// In the boot_device.mirror case, nothing specifies partition numbers
+				// so match existing partitions only when `wipeTable` is false
+				if !util.IsTrue(disk.WipeTable) {
+					// check for reserved partlabels
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+
 			}
 		}
 	}

--- a/config/fcos/v1_4/translate_test.go
+++ b/config/fcos/v1_4/translate_test.go
@@ -1423,3 +1423,242 @@ func TestTranslateBootDevice(t *testing.T) {
 		})
 	}
 }
+
+func TestRootPartitionConstraints(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     Config
+		report report.Report
+	}{
+		{
+			name: "root constrained by auto-positioned partition",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(0), // fill available
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - will be placed after root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root constrained by auto-positioned partition with explicit root start",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		// Root partition NOT constrained because next partition has explicit StartMiB
+		{
+			name: "root not constrained with explicit StartMiB after",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position - does NOT constrain root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		// Root partition constrained by auto-positioned partition even when
+		// an explicit partition is also present
+		{
+			name: "root constrained by auto-positioned partition with explicit also present",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition too small",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(4096),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootTooSmall.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "size_mib"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition exactly 8GiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		{
+			name: "root constrained with nil sizeMiB and nil startMiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+									{
+										Label: util.StrToPtr("data"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			r = confutil.TranslateReportPaths(r, translations)
+			assert.Equal(t, test.report, r, "report mismatch")
+		})
+	}
+}

--- a/config/fcos/v1_5/translate.go
+++ b/config/fcos/v1_5/translate.go
@@ -71,16 +71,34 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	for i, disk := range ret.Storage.Disks {
-		// In the boot_device.mirror case, nothing specifies partition numbers
-		// so match existing partitions only when `wipeTable` is false
-		if !util.IsTrue(disk.WipeTable) {
-			for j, partition := range disk.Partitions {
-				// check for reserved partlabels
-				if partition.Label != nil {
-					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
-						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+		for p, partition := range disk.Partitions {
+			// check for root partition size constraints
+			if partition.Label != nil {
+				if *partition.Label == "root" {
+					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
+						for idx := range disk.Partitions {
+							if idx == p {
+								continue
+							}
+							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
+								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
+								break
+							}
+						}
+					} else if *partition.SizeMiB < 8192 {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "size_mib"), common.ErrRootTooSmall)
 					}
 				}
+
+				// In the boot_device.mirror case, nothing specifies partition numbers
+				// so match existing partitions only when `wipeTable` is false
+				if !util.IsTrue(disk.WipeTable) {
+					// check for reserved partlabels
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+
 			}
 		}
 	}

--- a/config/fcos/v1_5/translate_test.go
+++ b/config/fcos/v1_5/translate_test.go
@@ -1506,6 +1506,245 @@ func TestTranslateBootDevice(t *testing.T) {
 	}
 }
 
+func TestRootPartitionConstraints(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     Config
+		report report.Report
+	}{
+		{
+			name: "root constrained by auto-positioned partition",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(0), // fill available
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - will be placed after root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root constrained by auto-positioned partition with explicit root start",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		// Root partition NOT constrained because next partition has explicit StartMiB
+		{
+			name: "root not constrained with explicit StartMiB after",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position - does NOT constrain root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		// Root partition constrained by auto-positioned partition even when
+		// an explicit partition is also present
+		{
+			name: "root constrained by auto-positioned partition with explicit also present",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition too small",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(4096),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootTooSmall.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "size_mib"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition exactly 8GiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		{
+			name: "root constrained with nil sizeMiB and nil startMiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+									{
+										Label: util.StrToPtr("data"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			r = confutil.TranslateReportPaths(r, translations)
+			assert.Equal(t, test.report, r, "report mismatch")
+		})
+	}
+}
+
 // TestTranslateGrub tests translating the Butane config Grub section.
 func TestTranslateGrub(t *testing.T) {
 	// Some tests below have the same translations

--- a/config/fcos/v1_6/translate.go
+++ b/config/fcos/v1_6/translate.go
@@ -71,16 +71,34 @@ func (c Config) ToIgn3_5Unvalidated(options common.TranslateOptions) (types.Conf
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	for i, disk := range ret.Storage.Disks {
-		// In the boot_device.mirror case, nothing specifies partition numbers
-		// so match existing partitions only when `wipeTable` is false
-		if !util.IsTrue(disk.WipeTable) {
-			for j, partition := range disk.Partitions {
-				// check for reserved partlabels
-				if partition.Label != nil {
-					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
-						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+		for p, partition := range disk.Partitions {
+			// check for root partition size constraints
+			if partition.Label != nil {
+				if *partition.Label == "root" {
+					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
+						for idx := range disk.Partitions {
+							if idx == p {
+								continue
+							}
+							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
+								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
+								break
+							}
+						}
+					} else if *partition.SizeMiB < 8192 {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "size_mib"), common.ErrRootTooSmall)
 					}
 				}
+
+				// In the boot_device.mirror case, nothing specifies partition numbers
+				// so match existing partitions only when `wipeTable` is false
+				if !util.IsTrue(disk.WipeTable) {
+					// check for reserved partlabels
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+
 			}
 		}
 	}

--- a/config/fcos/v1_6/translate_test.go
+++ b/config/fcos/v1_6/translate_test.go
@@ -1506,6 +1506,245 @@ func TestTranslateBootDevice(t *testing.T) {
 	}
 }
 
+func TestRootPartitionConstraints(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     Config
+		report report.Report
+	}{
+		{
+			name: "root constrained by auto-positioned partition",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(0), // fill available
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - will be placed after root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root constrained by auto-positioned partition with explicit root start",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		// Root partition NOT constrained because next partition has explicit StartMiB
+		{
+			name: "root not constrained with explicit StartMiB after",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position - does NOT constrain root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		// Root partition constrained by auto-positioned partition even when
+		// an explicit partition is also present
+		{
+			name: "root constrained by auto-positioned partition with explicit also present",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition too small",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(4096),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootTooSmall.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "size_mib"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition exactly 8GiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		{
+			name: "root constrained with nil sizeMiB and nil startMiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+									{
+										Label: util.StrToPtr("data"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			r = confutil.TranslateReportPaths(r, translations)
+			assert.Equal(t, test.report, r, "report mismatch")
+		})
+	}
+}
+
 // TestTranslateGrub tests translating the Butane config Grub section.
 func TestTranslateGrub(t *testing.T) {
 	// Some tests below have the same translations

--- a/config/fcos/v1_7/translate.go
+++ b/config/fcos/v1_7/translate.go
@@ -71,16 +71,34 @@ func (c Config) ToIgn3_6Unvalidated(options common.TranslateOptions) (types.Conf
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	for i, disk := range ret.Storage.Disks {
-		// In the boot_device.mirror case, nothing specifies partition numbers
-		// so match existing partitions only when `wipeTable` is false
-		if !util.IsTrue(disk.WipeTable) {
-			for j, partition := range disk.Partitions {
-				// check for reserved partlabels
-				if partition.Label != nil {
-					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
-						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+		for p, partition := range disk.Partitions {
+			// check for root partition size constraints
+			if partition.Label != nil {
+				if *partition.Label == "root" {
+					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
+						for idx := range disk.Partitions {
+							if idx == p {
+								continue
+							}
+							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
+								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
+								break
+							}
+						}
+					} else if *partition.SizeMiB < 8192 {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "size_mib"), common.ErrRootTooSmall)
 					}
 				}
+
+				// In the boot_device.mirror case, nothing specifies partition numbers
+				// so match existing partitions only when `wipeTable` is false
+				if !util.IsTrue(disk.WipeTable) {
+					// check for reserved partlabels
+					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrWrongPartitionNumber)
+					}
+				}
+
 			}
 		}
 	}

--- a/config/fcos/v1_7/translate_test.go
+++ b/config/fcos/v1_7/translate_test.go
@@ -1506,6 +1506,246 @@ func TestTranslateBootDevice(t *testing.T) {
 	}
 }
 
+func TestRootPartitionConstraints(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     Config
+		report report.Report
+	}{
+		{
+			name: "root constrained by auto-positioned partition",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(0), // fill available
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - will be placed after root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root constrained by auto-positioned partition with explicit root start",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		// Root partition NOT constrained because next partition has explicit StartMiB
+		{
+			name: "root not constrained with explicit StartMiB after",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position - does NOT constrain root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		// Root partition constrained by auto-positioned partition even when
+		// an explicit partition is also present
+		{
+			name: "root constrained by auto-positioned partition with explicit also present",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		// Root partition too small (explicit size < 8192 MiB)
+		{
+			name: "root partition too small",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(4096),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootTooSmall.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "size_mib"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition exactly 8GiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		{
+			name: "root constrained with nil sizeMiB and nil startMiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+									{
+										Label: util.StrToPtr("data"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := test.in.ToIgn3_6Unvalidated(common.TranslateOptions{})
+			r = confutil.TranslateReportPaths(r, translations)
+			assert.Equal(t, test.report, r, "report mismatch")
+		})
+	}
+}
+
 // TestTranslateGrub tests translating the Butane config Grub section.
 func TestTranslateGrub(t *testing.T) {
 	// Some tests below have the same translations

--- a/config/fcos/v1_8_exp/translate.go
+++ b/config/fcos/v1_8_exp/translate.go
@@ -71,14 +71,31 @@ func (c Config) ToIgn3_7Unvalidated(options common.TranslateOptions) (types.Conf
 	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	for i, disk := range ret.Storage.Disks {
-		// In the boot_device.mirror case, nothing specifies partition numbers
-		// so match existing partitions only when `wipeTable` is false
-		if !util.IsTrue(disk.WipeTable) {
-			for j, partition := range disk.Partitions {
-				// check for reserved partlabels
-				if partition.Label != nil {
+		for p, partition := range disk.Partitions {
+			// check for root partition size constraints
+			if partition.Label != nil {
+				if *partition.Label == "root" {
+					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
+						for idx := range disk.Partitions {
+							if idx == p {
+								continue
+							}
+							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
+								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
+								break
+							}
+						}
+					} else if *partition.SizeMiB < 8192 {
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "size_mib"), common.ErrRootTooSmall)
+					}
+				}
+
+				// In the boot_device.mirror case, nothing specifies partition numbers
+				// so match existing partitions only when `wipeTable` is false
+				if !util.IsTrue(disk.WipeTable) {
+					// check for reserved partlabels
 					if (*partition.Label == "BIOS-BOOT" && partition.Number != 1) || (*partition.Label == "PowerPC-PReP-boot" && partition.Number != 1) || (*partition.Label == "EFI-SYSTEM" && partition.Number != 2) || (*partition.Label == "boot" && partition.Number != 3) || (*partition.Label == "root" && partition.Number != 4) {
-						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", j, "label"), common.ErrWrongPartitionNumber)
+						r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrWrongPartitionNumber)
 					}
 				}
 			}

--- a/config/fcos/v1_8_exp/translate_test.go
+++ b/config/fcos/v1_8_exp/translate_test.go
@@ -1637,3 +1637,242 @@ func TestTranslateGrub(t *testing.T) {
 		})
 	}
 }
+
+func TestRootPartitionConstraints(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     Config
+		report report.Report
+	}{
+		{
+			name: "root constrained by auto-positioned partition",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(0), // fill available
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - will be placed after root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root constrained by auto-positioned partition with explicit root start",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		// Root partition NOT constrained because next partition has explicit StartMiB
+		{
+			name: "root not constrained with explicit StartMiB after",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position - does NOT constrain root
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		// Root partition constrained by auto-positioned partition even when
+		// an explicit partition is also present
+		{
+			name: "root constrained by auto-positioned partition with explicit also present",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:    util.StrToPtr("root"),
+										Number:   4,
+										SizeMiB:  util.IntToPtr(0), // fill available
+										StartMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:    util.StrToPtr("var"),
+										StartMiB: util.IntToPtr(0), // auto-positioned - constrains root
+									},
+									{
+										Label:    util.StrToPtr("data"),
+										StartMiB: util.IntToPtr(10240), // explicit position
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition too small",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(4096),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootTooSmall.Error(),
+						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "size_mib"),
+					},
+				},
+			},
+		},
+		{
+			name: "root partition exactly 8GiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root"),
+										Number:  4,
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{},
+		},
+		{
+			name: "root constrained with nil sizeMiB and nil startMiB",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+									{
+										Label: util.StrToPtr("data"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{
+				Entries: []report.Entry{
+					{
+						Kind:    report.Warn,
+						Message: common.ErrRootConstrained.Error(),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := test.in.ToIgn3_7Unvalidated(common.TranslateOptions{})
+			r = confutil.TranslateReportPaths(r, translations)
+			assert.Equal(t, test.report, r, "report mismatch")
+		})
+	}
+}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,9 @@ nav_order: 9
 
 ### Misc. changes
 
+- Warn on root partition size is too small _(fcos 1.3.0-1.8.0-exp)_
+- Warn on root partition constrained by another partition _(fcos 1.3.0-1.8.0-exp)_
+
 ### Docs changes
 
 


### PR DESCRIPTION
https://github.com/coreos/butane/issues/211



Note I somehow dropped the '1' in the version for FCOS in the commit messages.. but before I update the commit structure lets make sure we are happy with the functional changes. Look at the first 2 commits, i.e the exp changes this is basically propagated to all versions back to 1_3 as you can see later with the fixup commits. Once approved I will merge the fixup commits with a rename to the commits to be inclusive of the changes! 