### PR TITLE
docs: clarify group fields in config specs

### DIFF
--- a/docs/config-fcos-v1_0.md
+++ b/docs/config-fcos-v1_0.md
@@ -75,9 +75,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -85,18 +85,18 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
 * **_systemd_** (object): describes the desired state of the systemd units.

--- a/docs/config-fcos-v1_0.md
+++ b/docs/config-fcos-v1_0.md
@@ -91,10 +91,10 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-fcos-v1_1.md
+++ b/docs/config-fcos-v1_1.md
@@ -123,10 +123,10 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-fcos-v1_1.md
+++ b/docs/config-fcos-v1_1.md
@@ -107,9 +107,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -117,18 +117,18 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.

--- a/docs/config-fcos-v1_2.md
+++ b/docs/config-fcos-v1_2.md
@@ -108,9 +108,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -118,18 +118,18 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/config-fcos-v1_2.md
+++ b/docs/config-fcos-v1_2.md
@@ -124,10 +124,10 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-fcos-v1_3.md
+++ b/docs/config-fcos-v1_3.md
@@ -108,9 +108,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -118,18 +118,18 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/config-fcos-v1_3.md
+++ b/docs/config-fcos-v1_3.md
@@ -124,10 +124,10 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-fcos-v1_4.md
+++ b/docs/config-fcos-v1_4.md
@@ -108,9 +108,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -118,18 +118,18 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/config-fcos-v1_4.md
+++ b/docs/config-fcos-v1_4.md
@@ -124,10 +124,10 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-fcos-v1_5-exp.md
+++ b/docs/config-fcos-v1_5-exp.md
@@ -110,9 +110,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -120,18 +120,18 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/config-fcos-v1_5-exp.md
+++ b/docs/config-fcos-v1_5-exp.md
@@ -126,10 +126,10 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-flatcar-v1_0.md
+++ b/docs/config-flatcar-v1_0.md
@@ -124,10 +124,10 @@ The Flatcar configuration is a YAML document conforming to the following specifi
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-flatcar-v1_0.md
+++ b/docs/config-flatcar-v1_0.md
@@ -108,9 +108,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -118,18 +118,18 @@ The Flatcar configuration is a YAML document conforming to the following specifi
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/config-flatcar-v1_1-exp.md
+++ b/docs/config-flatcar-v1_1-exp.md
@@ -126,10 +126,10 @@ The Flatcar configuration is a YAML document conforming to the following specifi
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-flatcar-v1_1-exp.md
+++ b/docs/config-flatcar-v1_1-exp.md
@@ -110,9 +110,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -120,18 +120,18 @@ The Flatcar configuration is a YAML document conforming to the following specifi
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/config-openshift-v4_10.md
+++ b/docs/config-openshift-v4_10.md
@@ -98,9 +98,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
     * **name** (string): the name of the luks device.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.

--- a/docs/config-openshift-v4_11.md
+++ b/docs/config-openshift-v4_11.md
@@ -98,9 +98,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
     * **name** (string): the name of the luks device.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.

--- a/docs/config-openshift-v4_12-exp.md
+++ b/docs/config-openshift-v4_12-exp.md
@@ -100,9 +100,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
     * **name** (string): the name of the luks device.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.

--- a/docs/config-openshift-v4_8.md
+++ b/docs/config-openshift-v4_8.md
@@ -97,9 +97,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
     * **name** (string): the name of the luks device.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -97,9 +97,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
     * **name** (string): the name of the luks device.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.

--- a/docs/config-rhcos-v0_1.md
+++ b/docs/config-rhcos-v0_1.md
@@ -124,10 +124,10 @@ The RHEL CoreOS configuration is a YAML document conforming to the following spe
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/config-rhcos-v0_1.md
+++ b/docs/config-rhcos-v0_1.md
@@ -108,9 +108,9 @@ The RHEL CoreOS configuration is a YAML document conforming to the following spe
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -118,18 +118,18 @@ The RHEL CoreOS configuration is a YAML document conforming to the following spe
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,7 +21,7 @@ nav_order: 9
 
 ### Docs changes
 
-
+- Clarify spec docs for `files`/`directories`/`links` `group` fields
 
 
 ## Butane 0.15.0 (2022-06-23)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,7 @@ nav_order: 9
 ### Docs changes
 
 - Clarify spec docs for `files`/`directories`/`links` `group` fields
+- Document that `user`/`group` fields aren't applied to hard links
 
 
 ## Butane 0.15.0 (2022-06-23)


### PR DESCRIPTION
They specify the group that should be applied to the inode, not the primary group of the inode's owner.