### PR TITLE
Add new r4e variant

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -60,19 +60,23 @@ var (
 	ErrInvalidKernelType      = errors.New("must be empty, \"default\", or \"realtime\"")
 	ErrBtrfsSupport           = errors.New("btrfs is not supported in this spec version")
 	ErrFilesystemNoneSupport  = errors.New("format \"none\" is not supported in this spec version")
-	ErrDirectorySupport       = errors.New("directories are not supported in this spec version")
 	ErrFileSchemeSupport      = errors.New("file contents source must be data URL in this spec version")
 	ErrFileAppendSupport      = errors.New("appending to files is not supported in this spec version")
 	ErrFileCompressionSupport = errors.New("file compression is not supported in this spec version")
 	ErrFileSpecialModeSupport = errors.New("special mode bits are not supported in this spec version")
-	ErrLinkSupport            = errors.New("links are not supported in this spec version")
 	ErrGroupSupport           = errors.New("groups are not supported in this spec version")
 	ErrUserFieldSupport       = errors.New("fields other than \"name\" and \"ssh_authorized_keys\" are not supported in this spec version")
 	ErrUserNameSupport        = errors.New("users other than \"core\" are not supported in this spec version")
 	ErrKernelArgumentSupport  = errors.New("this field cannot be used for kernel arguments in this spec version; use openshift.kernel_arguments instead")
 
 	// Storage
-	ErrClevisSupport = errors.New("clevis is not supported in this spec version")
+	ErrClevisSupport     = errors.New("clevis is not supported in this spec version")
+	ErrDirectorySupport  = errors.New("directories are not supported in this spec version")
+	ErrDiskSupport       = errors.New("disk customization is not supported in this spec version")
+	ErrFilesystemSupport = errors.New("filesystem customization is not supported in this spec version")
+	ErrLinkSupport       = errors.New("links are not supported in this spec version")
+	ErrLuksSupport       = errors.New("luks is not supported in this spec version")
+	ErrRaidSupport       = errors.New("raid is not supported in this spec version")
 
 	// Extensions
 	ErrExtensionNameRequired = errors.New("field \"name\" is required")
@@ -80,4 +84,7 @@ var (
 	// Grub
 	ErrGrubUserNameNotSpecified = errors.New("field \"name\" is required")
 	ErrGrubPasswordNotSpecified = errors.New("field \"password_hash\" is required")
+
+	// Kernel arguments
+	ErrGeneralKernelArgumentSupport = errors.New("kernel argument customization is not supported in this spec version")
 )

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ import (
 	openshift4_8 "github.com/coreos/butane/config/openshift/v4_8"
 	openshift4_9 "github.com/coreos/butane/config/openshift/v4_9"
 	r4e1_0 "github.com/coreos/butane/config/r4e/v1_0"
+	r4e1_1_exp "github.com/coreos/butane/config/r4e/v1_1_exp"
 	rhcos0_1 "github.com/coreos/butane/config/rhcos/v0_1"
 
 	"github.com/coreos/go-semver/semver"
@@ -66,6 +67,7 @@ func init() {
 	RegisterTranslator("openshift", "4.12.0", openshift4_12.ToConfigBytes)
 	RegisterTranslator("openshift", "4.13.0-experimental", openshift4_13_exp.ToConfigBytes)
 	RegisterTranslator("r4e", "1.0.0", r4e1_0.ToIgn3_3Bytes)
+	RegisterTranslator("r4e", "1.1.0-experimental", r4e1_1_exp.ToIgn3_4Bytes)
 	RegisterTranslator("rhcos", "0.1.0", rhcos0_1.ToIgn3_2Bytes)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ import (
 	openshift4_13_exp "github.com/coreos/butane/config/openshift/v4_13_exp"
 	openshift4_8 "github.com/coreos/butane/config/openshift/v4_8"
 	openshift4_9 "github.com/coreos/butane/config/openshift/v4_9"
+	r4e1_0 "github.com/coreos/butane/config/r4e/v1_0"
 	rhcos0_1 "github.com/coreos/butane/config/rhcos/v0_1"
 
 	"github.com/coreos/go-semver/semver"
@@ -64,6 +65,7 @@ func init() {
 	RegisterTranslator("openshift", "4.11.0", openshift4_11.ToConfigBytes)
 	RegisterTranslator("openshift", "4.12.0", openshift4_12.ToConfigBytes)
 	RegisterTranslator("openshift", "4.13.0-experimental", openshift4_13_exp.ToConfigBytes)
+	RegisterTranslator("r4e", "1.0.0", r4e1_0.ToIgn3_3Bytes)
 	RegisterTranslator("rhcos", "0.1.0", rhcos0_1.ToIgn3_2Bytes)
 }
 

--- a/config/r4e/v1_0/schema.go
+++ b/config/r4e/v1_0/schema.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_0
+
+import (
+	base "github.com/coreos/butane/base/v0_4"
+)
+
+type Config struct {
+	base.Config `yaml:",inline"`
+}

--- a/config/r4e/v1_0/translate.go
+++ b/config/r4e/v1_0/translate.go
@@ -1,0 +1,79 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_0
+
+import (
+	"github.com/coreos/butane/config/common"
+	cutil "github.com/coreos/butane/config/util"
+	"github.com/coreos/butane/translate"
+
+	"github.com/coreos/ignition/v2/config/v3_3/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+// ToIgn3_3Unvalidated translates the config to an Ignition config.  It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	ret, ts, r := c.Config.ToIgn3_3Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
+
+	checkForForbiddenFields(ret, &r)
+
+	return ret, ts, r
+}
+
+// Checks and adds the appropiate errors when unsupported fields on r4e are
+// provided
+func checkForForbiddenFields(t types.Config, r *report.Report) {
+	for i := range t.KernelArguments.ShouldExist {
+		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_exist", i), common.ErrGeneralKernelArgumentSupport)
+	}
+	for i := range t.KernelArguments.ShouldNotExist {
+		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_not_exist", i), common.ErrGeneralKernelArgumentSupport)
+	}
+	for i := range t.Storage.Disks {
+		r.AddOnError(path.New("path", "json", "storage", "disks", i), common.ErrDiskSupport)
+	}
+	for i := range t.Storage.Filesystems {
+		r.AddOnError(path.New("path", "json", "storage", "filesystems", i), common.ErrFilesystemSupport)
+	}
+	for i := range t.Storage.Luks {
+		r.AddOnError(path.New("path", "json", "storage", "luks", i), common.ErrLuksSupport)
+	}
+	for i := range t.Storage.Raid {
+		r.AddOnError(path.New("path", "json", "storage", "raid", i), common.ErrRaidSupport)
+	}
+}
+
+// ToIgn3_3 translates the config to an Ignition config.  It returns a
+// report of any errors or warnings in the source and resultant config.  If
+// the report has fatal errors or it encounters other problems translating,
+// an error is returned.
+func (c Config) ToIgn3_3(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_3Unvalidated", options)
+	return cfg.(types.Config), r, err
+}
+
+// ToIgn3_3Bytes translates from a v1.0 Butane config to a v3.3.0 Ignition config. It returns a report of any errors or
+// warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
+// translating, an error is returned.
+func ToIgn3_3Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_3", options)
+}

--- a/config/r4e/v1_0/translate_test.go
+++ b/config/r4e/v1_0/translate_test.go
@@ -1,0 +1,175 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_0
+
+import (
+	"fmt"
+	"testing"
+
+	base "github.com/coreos/butane/base/v0_4"
+	"github.com/coreos/butane/config/common"
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that we error on unsupported fields for r4e
+func TestTranslateInvalid(t *testing.T) {
+	type InvalidEntry struct {
+		Kind report.EntryKind
+		Err  error
+		Path path.ContextPath
+	}
+	tests := []struct {
+		In      Config
+		Entries []InvalidEntry
+	}{
+		// we don't support setting kernel arguments
+		{
+			Config{
+				Config: base.Config{
+					KernelArguments: base.KernelArguments{
+						ShouldExist: []base.KernelArgument{
+							"test",
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrGeneralKernelArgumentSupport,
+					path.New("path", "json", "kernel_arguments", "should_exist", 0),
+				},
+			},
+		},
+		// we don't support unsetting kernel arguments either
+		{
+			Config{
+				Config: base.Config{
+					KernelArguments: base.KernelArguments{
+						ShouldNotExist: []base.KernelArgument{
+							"another-test",
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrGeneralKernelArgumentSupport,
+					path.New("path", "json", "kernel_arguments", "should_not_exist", 0),
+				},
+			},
+		},
+		// disk customizations are made in Image Builder, r4e doesn't support this via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "some-device",
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrDiskSupport,
+					path.New("path", "json", "storage", "disks", 0),
+				},
+			},
+		},
+		// filesystem customizations are made in Image Builder, r4e doesn't support this via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Filesystems: []base.Filesystem{
+							{
+								Device: "/dev/disk/by-label/TEST",
+								Path:   util.StrToPtr("/var"),
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrFilesystemSupport,
+					path.New("path", "json", "storage", "filesystems", 0),
+				},
+			},
+		},
+		// default luks configuration is made in Image Builder for r4e, we don't support this via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Luks: []base.Luks{
+							{
+								Label: util.StrToPtr("some-label"),
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrLuksSupport,
+					path.New("path", "json", "storage", "luks", 0),
+				},
+			},
+		},
+		// we don't support configuring raid via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Raid: []base.Raid{
+							{
+								Name: "some-name",
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrRaidSupport,
+					path.New("path", "json", "storage", "raid", 0),
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.Entries {
+				expectedReport.AddOnError(entry.Path, entry.Err)
+			}
+			actual, translations, r := test.In.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
+	}
+}

--- a/config/r4e/v1_1_exp/schema.go
+++ b/config/r4e/v1_1_exp/schema.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1_exp
+
+import (
+	base "github.com/coreos/butane/base/v0_5_exp"
+)
+
+type Config struct {
+	base.Config `yaml:",inline"`
+}

--- a/config/r4e/v1_1_exp/translate.go
+++ b/config/r4e/v1_1_exp/translate.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1_exp
+
+import (
+	"github.com/coreos/butane/config/common"
+	cutil "github.com/coreos/butane/config/util"
+	"github.com/coreos/butane/translate"
+	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+// ToIgn3_4Unvalidated translates the config to an Ignition config.  It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	ret, ts, r := c.Config.ToIgn3_4Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
+
+	checkForForbiddenFields(ret, &r)
+
+	return ret, ts, r
+}
+
+// Checks and adds the appropiate errors when unsupported fields on r4e are
+// provided
+func checkForForbiddenFields(t types.Config, r *report.Report) {
+	for i := range t.KernelArguments.ShouldExist {
+		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_exist", i), common.ErrGeneralKernelArgumentSupport)
+	}
+	for i := range t.KernelArguments.ShouldNotExist {
+		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_not_exist", i), common.ErrGeneralKernelArgumentSupport)
+	}
+	for i := range t.Storage.Disks {
+		r.AddOnError(path.New("path", "json", "storage", "disks", i), common.ErrDiskSupport)
+	}
+	for i := range t.Storage.Filesystems {
+		r.AddOnError(path.New("path", "json", "storage", "filesystems", i), common.ErrFilesystemSupport)
+	}
+	for i := range t.Storage.Luks {
+		r.AddOnError(path.New("path", "json", "storage", "luks", i), common.ErrLuksSupport)
+	}
+	for i := range t.Storage.Raid {
+		r.AddOnError(path.New("path", "json", "storage", "raid", i), common.ErrRaidSupport)
+	}
+}
+
+// ToIgn3_4 translates the config to an Ignition config. It returns a
+// report of any errors or warnings in the source and resultant config. If
+// the report has fatal errors or it encounters other problems translating,
+// an error is returned.
+func (c Config) ToIgn3_4(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_4Unvalidated", options)
+	return cfg.(types.Config), r, err
+}
+
+// ToIgn3_4Bytes translates from a v1.1 Butane config to a v3.4.0 Ignition config. It returns a report of any errors or
+// warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
+// translating, an error is returned.
+func ToIgn3_4Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_4", options)
+}

--- a/config/r4e/v1_1_exp/translate_test.go
+++ b/config/r4e/v1_1_exp/translate_test.go
@@ -1,0 +1,175 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1_exp
+
+import (
+	"fmt"
+	"testing"
+
+	base "github.com/coreos/butane/base/v0_5_exp"
+	"github.com/coreos/butane/config/common"
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that we error on unsupported fields for r4e
+func TestTranslateInvalid(t *testing.T) {
+	type InvalidEntry struct {
+		Kind report.EntryKind
+		Err  error
+		Path path.ContextPath
+	}
+	tests := []struct {
+		In      Config
+		Entries []InvalidEntry
+	}{
+		// we don't support setting kernel arguments
+		{
+			Config{
+				Config: base.Config{
+					KernelArguments: base.KernelArguments{
+						ShouldExist: []base.KernelArgument{
+							"test",
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrGeneralKernelArgumentSupport,
+					path.New("path", "json", "kernel_arguments", "should_exist", 0),
+				},
+			},
+		},
+		// we don't support unsetting kernel arguments either
+		{
+			Config{
+				Config: base.Config{
+					KernelArguments: base.KernelArguments{
+						ShouldNotExist: []base.KernelArgument{
+							"another-test",
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrGeneralKernelArgumentSupport,
+					path.New("path", "json", "kernel_arguments", "should_not_exist", 0),
+				},
+			},
+		},
+		// disk customizations are made in Image Builder, r4e doesn't support this via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "some-device",
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrDiskSupport,
+					path.New("path", "json", "storage", "disks", 0),
+				},
+			},
+		},
+		// filesystem customizations are made in Image Builder, r4e doesn't support this via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Filesystems: []base.Filesystem{
+							{
+								Device: "/dev/disk/by-label/TEST",
+								Path:   util.StrToPtr("/var"),
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrFilesystemSupport,
+					path.New("path", "json", "storage", "filesystems", 0),
+				},
+			},
+		},
+		// default luks configuration is made in Image Builder for r4e, we don't support this via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Luks: []base.Luks{
+							{
+								Label: util.StrToPtr("some-label"),
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrLuksSupport,
+					path.New("path", "json", "storage", "luks", 0),
+				},
+			},
+		},
+		// we don't support configuring raid via ignition
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Raid: []base.Raid{
+							{
+								Name: "some-name",
+							},
+						},
+					},
+				},
+			},
+			[]InvalidEntry{
+				{
+					report.Error,
+					common.ErrRaidSupport,
+					path.New("path", "json", "storage", "raid", 0),
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
+			var expectedReport report.Report
+			for _, entry := range test.Entries {
+				expectedReport.AddOnError(entry.Path, entry.Err)
+			}
+			actual, translations, r := test.In.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			assert.Equal(t, expectedReport, r, "report mismatch")
+			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
+		})
+	}
+}

--- a/docs/config-r4e-v1_0.md
+++ b/docs/config-r4e-v1_0.md
@@ -1,0 +1,143 @@
+---
+title: RHEL for Edge v1.0.0
+parent: Configuration specifications
+nav_order: 199
+---
+
+# RHEL for Edge Specification v1.0.0
+
+The RHEL for Edge configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+
+* **variant** (string): used to differentiate configs for different operating systems. Must be `r4e` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.0.0` and generates Ignition configs with version `3.3.0`.
+* **_ignition_** (object): metadata about the configuration itself.
+  * **_config_** (objects): options related to the configuration.
+    * **_merge_** (list of objects): a list of the configs to be merged to the current config.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_replace_** (object): the config that will replace the current.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
+    * **_http_response_headers_** (integer) the time to wait (in seconds) for the server's response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.
+    * **_http_total_** (integer) the time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.
+  * **_security_** (object): options relating to network security.
+    * **_tls_** (object): options relating to TLS when fetching resources over `https`.
+      * **_certificate_authorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`, `inline`, or `local`.
+        * **_source_** (string): the URL of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+        * **_inline_** (string): the contents of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
+        * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
+        * **_compression_** (string): the type of compression used on the certificate (null or gzip). Compression cannot be used with S3.
+        * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+          * **name** (string): the header name.
+          * **_value_** (string): the header contents.
+        * **_verification_** (object): options related to the verification of the certificate.
+          * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
+    * **_http_proxy_** (string): will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by `https_proxy` or `no_proxy`.
+    * **_https_proxy_** (string): will be used as the proxy URL for HTTPS requests unless overridden by `no_proxy`.
+    * **_no_proxy_** (list of strings): specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an `IP address prefix (1.2.3.4)`, `an IP address prefix in CIDR notation (1.2.3.4/8)`, `a domain name`, or `a special DNS label (*)`. An IP address prefix and domain name can also include a literal port number `(1.2.3.4:80)`. A domain name matches that name and all subdomains. A domain name with a leading `.` matches subdomains only. For example `foo.com` matches `foo.com` and `bar.foo.com`; `.y.com` matches `x.y.com` but not `y.com`. A single asterisk `(*)` indicates that no proxying should be done.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
+    * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
+    * **_contents_** (object): options related to the contents of the file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents to append. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents to append, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the appended contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_mode_** (integer): the file's permission mode. Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
+    * **_user_** (object): specifies the file's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
+  * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
+    * **_mode_** (integer): the directory's permission mode. Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path.
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
+  * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
+    * **target** (string): the target path of the link
+    * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.
+    * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
+    * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units. Every unit must have a unique `name`.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service").
+    * **_enabled_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit. Every drop-in must have a unique `name`.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
+    * **name** (string): the username for the account.
+    * **_password_hash_** (string): the hashed password for the account.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_home_dir_** (string): the home directory of the account.
+    * **_no_create_home_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primary_group_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_no_user_group_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_no_log_init_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_should_exist_** (boolean) whether or not the user with the specified `name` should exist. If omitted, it defaults to true. If false, then Ignition will delete the specified user.
+    * **_system_** (bool): whether or not this account should be a system account. This only has an effect if the account doesn't exist yet.
+  * **_groups_** (list of objects): the list of groups to be added. All groups must have a unique `name`.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_password_hash_** (string): the hashed password of the new group.
+    * **_should_exist_** (boolean) whether or not the group with the specified `name` should exist. If omitted, it defaults to true. If false, then Ignition will delete the specified group.
+    * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+
+[part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+[rfc2397]: https://tools.ietf.org/html/rfc2397
+[systemd-escape]: https://www.freedesktop.org/software/systemd/man/systemd-escape.html

--- a/docs/config-r4e-v1_1-exp.md
+++ b/docs/config-r4e-v1_1-exp.md
@@ -1,0 +1,145 @@
+---
+title: RHEL for Edge v1.1.0-experimental
+parent: Configuration specifications
+nav_order: 200
+---
+
+# RHEL for Edge Specification v1.1.0-experimental
+
+**Note: This configuration is experimental and has not been stabilized. It is subject to change without warning or announcement.**
+
+The RHEL for Edge configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+
+* **variant** (string): used to differentiate configs for different operating systems. Must be `r4e` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.1.0-experimental` and generates Ignition configs with version `3.4.0-experimental`.
+* **_ignition_** (object): metadata about the configuration itself.
+  * **_config_** (objects): options related to the configuration.
+    * **_merge_** (list of objects): a list of the configs to be merged to the current config.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_replace_** (object): the config that will replace the current.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
+    * **_http_response_headers_** (integer) the time to wait (in seconds) for the server's response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.
+    * **_http_total_** (integer) the time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.
+  * **_security_** (object): options relating to network security.
+    * **_tls_** (object): options relating to TLS when fetching resources over `https`.
+      * **_certificate_authorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`, `inline`, or `local`.
+        * **_source_** (string): the URL of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+        * **_inline_** (string): the contents of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
+        * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
+        * **_compression_** (string): the type of compression used on the certificate (null or gzip). Compression cannot be used with S3.
+        * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+          * **name** (string): the header name.
+          * **_value_** (string): the header contents.
+        * **_verification_** (object): options related to the verification of the certificate.
+          * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
+    * **_http_proxy_** (string): will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by `https_proxy` or `no_proxy`.
+    * **_https_proxy_** (string): will be used as the proxy URL for HTTPS requests unless overridden by `no_proxy`.
+    * **_no_proxy_** (list of strings): specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an `IP address prefix (1.2.3.4)`, `an IP address prefix in CIDR notation (1.2.3.4/8)`, `a domain name`, or `a special DNS label (*)`. An IP address prefix and domain name can also include a literal port number `(1.2.3.4:80)`. A domain name matches that name and all subdomains. A domain name with a leading `.` matches subdomains only. For example `foo.com` matches `foo.com` and `bar.foo.com`; `.y.com` matches `x.y.com` but not `y.com`. A single asterisk `(*)` indicates that no proxying should be done.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
+    * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
+    * **_contents_** (object): options related to the contents of the file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents to append. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents to append, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the appended contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_mode_** (integer): the file's permission mode. Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
+    * **_user_** (object): specifies the file's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
+  * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
+    * **_mode_** (integer): the directory's permission mode. Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path.
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
+  * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
+    * **target** (string): the target path of the link
+    * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.
+    * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
+    * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units. Every unit must have a unique `name`.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service").
+    * **_enabled_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit. Every drop-in must have a unique `name`.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
+    * **name** (string): the username for the account.
+    * **_password_hash_** (string): the hashed password for the account.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_home_dir_** (string): the home directory of the account.
+    * **_no_create_home_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primary_group_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_no_user_group_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_no_log_init_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_should_exist_** (boolean) whether or not the user with the specified `name` should exist. If omitted, it defaults to true. If false, then Ignition will delete the specified user.
+    * **_system_** (bool): whether or not this account should be a system account. This only has an effect if the account doesn't exist yet.
+  * **_groups_** (list of objects): the list of groups to be added. All groups must have a unique `name`.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_password_hash_** (string): the hashed password of the new group.
+    * **_should_exist_** (boolean) whether or not the group with the specified `name` should exist. If omitted, it defaults to true. If false, then Ignition will delete the specified group.
+    * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+
+[part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+[rfc2397]: https://tools.ietf.org/html/rfc2397
+[systemd-escape]: https://www.freedesktop.org/software/systemd/man/systemd-escape.html

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,8 @@ nav_order: 9
 
 ### Features
 
+- Add RHEL for Edge (`r4e`) spec 1.0.0 and 1.1.0-experimental, targeting
+  Ignition spec 3.3.0 and 3.4.0-experimental respectively
 
 ### Bug fixes
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -28,6 +28,8 @@ We recommend that you always use the latest **stable** specification for your op
   - [v4.10.0](config-openshift-v4_10.md)
   - [v4.9.0](config-openshift-v4_9.md)
   - [v4.8.0](config-openshift-v4_8.md)
+- RHEL for Edge (`r4e`)
+  - [v1.0.0](config-r4e-v1_0.md)
 
 ## Experimental specification versions
 
@@ -39,6 +41,8 @@ Do not use **experimental** specifications for anything beyond **development and
   - [v1.1.0-experimental](config-flatcar-v1_1-exp.md)
 - OpenShift (`openshift`)
   - [v4.13.0-experimental](config-openshift-v4_13-exp.md)
+- RHEL for Edge (`r4e`)
+  - [v1.1.0-experimental](config-r4e-v1_1-exp.md)
 
 ## Deprecated specification versions
 
@@ -67,4 +71,6 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `openshift`    | 4.11.0              | 3.2.0              |
 | `openshift`    | 4.12.0              | 3.2.0              |
 | `openshift`    | 4.13.0-experimental | 3.4.0-experimental |
+| `r4e`          | 1.0.0               | 3.3.0              |
+| `r4e`          | 1.1.0-experimental  | 3.4.0-experimental |
 | `rhcos`        | 0.1.0               | 3.2.0              |


### PR DESCRIPTION
This PR adds a new rhel-for-edge variant `r4e` targeting ignition 3.3.0 as well as an experimental variant targeting ignition 3.4.0.

Closes #396 

Checklist:
*Right now we won't support:*
- [x]  storage.{disks, filesystems, luks, raid}
- [x] kernel_arguments
