### PR TITLE
Improve error on unsupported `rhcos` variant

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -27,6 +27,9 @@ var (
 	ErrInvalidSourceConfig    = errors.New("source config is invalid")
 	ErrInvalidGeneratedConfig = errors.New("config generated was invalid")
 
+	// deprecated variant/version
+	ErrRhcosVariantUnsupported = errors.New("rhcos variant has been removed; use openshift variant instead: https://coreos.github.io/butane/upgrading-openshift/")
+
 	// resources and trees
 	ErrTooManyResourceSources = errors.New("only one of the following can be set: inline, local, source")
 	ErrFilesDirEscape         = errors.New("local file path traverses outside the files directory")

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ func init() {
 	RegisterTranslator("openshift", "4.13.0-experimental", openshift4_13_exp.ToConfigBytes)
 	RegisterTranslator("r4e", "1.0.0", r4e1_0.ToIgn3_3Bytes)
 	RegisterTranslator("r4e", "1.1.0-experimental", r4e1_1_exp.ToIgn3_4Bytes)
+	RegisterTranslator("rhcos", "0.1.0", unsupportedRhcosVariant)
 }
 
 // RegisterTranslator registers a translator for the specified variant and
@@ -118,4 +119,8 @@ func TranslateBytes(input []byte, options common.TranslateBytesOptions) ([]byte,
 	}
 
 	return translator(input, options)
+}
+
+func unsupportedRhcosVariant(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return nil, report.Report{}, common.ErrRhcosVariantUnsupported
 }


### PR DESCRIPTION
Now that the rhcos variant has been removed, attempting to use an rhcos config produces a non-actionable error:

    Error translating config: No translator exists for variant rhcos with version 0.1.0

Add an explicit check and message:

    Error translating config: rhcos variant has been removed; use openshift variant instead: https://coreos.github.io/butane/upgrading-openshift/