### PR TITLE
base/util: avoid error if storage.trees.local value equals to FilesDir

### DIFF
--- a/base/util/file.go
+++ b/base/util/file.go
@@ -30,7 +30,7 @@ func EnsurePathWithinFilesDir(path, filesDir string) error {
 	if err != nil {
 		return err
 	}
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
+	if absPath != absBase && !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
 		return common.ErrFilesDirEscape
 	}
 	return nil

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Allow setting `storage.trees.local` to the `--files-dir` directory
 
 ### Misc. changes
 


### PR DESCRIPTION
Fixes https://github.com/coreos/butane/issues/119