### PR TITLE
base/v0_5_exp: remove `Option` wrapper types

### DIFF
--- a/base/v0_5_exp/schema.go
+++ b/base/v0_5_exp/schema.go
@@ -80,8 +80,6 @@ type Filesystem struct {
 	WithMountUnit  *bool    `yaml:"with_mount_unit" butane:"auto_skip"` // Added, not in Ignition spec
 }
 
-type FilesystemOption string
-
 type Group string
 
 type HTTPHeader struct {

--- a/base/v0_5_exp/schema.go
+++ b/base/v0_5_exp/schema.go
@@ -118,17 +118,15 @@ type Link struct {
 }
 
 type Luks struct {
-	Clevis     Clevis       `yaml:"clevis"`
-	Device     *string      `yaml:"device"`
-	KeyFile    Resource     `yaml:"key_file"`
-	Label      *string      `yaml:"label"`
-	Name       string       `yaml:"name"`
-	Options    []LuksOption `yaml:"options"`
-	UUID       *string      `yaml:"uuid"`
-	WipeVolume *bool        `yaml:"wipe_volume"`
+	Clevis     Clevis   `yaml:"clevis"`
+	Device     *string  `yaml:"device"`
+	KeyFile    Resource `yaml:"key_file"`
+	Label      *string  `yaml:"label"`
+	Name       string   `yaml:"name"`
+	Options    []string `yaml:"options"`
+	UUID       *string  `yaml:"uuid"`
+	WipeVolume *bool    `yaml:"wipe_volume"`
 }
-
-type LuksOption string
 
 type NodeGroup struct {
 	ID   *int    `yaml:"id"`
@@ -189,14 +187,12 @@ type Proxy struct {
 }
 
 type Raid struct {
-	Devices []Device     `yaml:"devices"`
-	Level   *string      `yaml:"level"`
-	Name    string       `yaml:"name"`
-	Options []RaidOption `yaml:"options"`
-	Spares  *int         `yaml:"spares"`
+	Devices []Device `yaml:"devices"`
+	Level   *string  `yaml:"level"`
+	Name    string   `yaml:"name"`
+	Options []string `yaml:"options"`
+	Spares  *int     `yaml:"spares"`
 }
-
-type RaidOption string
 
 type Resource struct {
 	Compression  *string      `yaml:"compression"`

--- a/config/openshift/v4_13_exp/translate_test.go
+++ b/config/openshift/v4_13_exp/translate_test.go
@@ -118,23 +118,23 @@ func TestTranslateConfig(t *testing.T) {
 								},
 								{
 									Name:    "b",
-									Options: []base.LuksOption{"b", "b"},
+									Options: []string{"b", "b"},
 								},
 								{
 									Name:    "c",
-									Options: []base.LuksOption{"c", "--cipher", "c"},
+									Options: []string{"c", "--cipher", "c"},
 								},
 								{
 									Name:    "d",
-									Options: []base.LuksOption{"--cipher=z"},
+									Options: []string{"--cipher=z"},
 								},
 								{
 									Name:    "e",
-									Options: []base.LuksOption{"-c", "z"},
+									Options: []string{"-c", "z"},
 								},
 								{
 									Name:    "f",
-									Options: []base.LuksOption{"--ciphertext"},
+									Options: []string{"--ciphertext"},
 								},
 							},
 						},

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,8 @@ nav_order: 9
 
 ### Misc. changes
 
+- Drop `LuksOption` and `RaidOption` types _(Go API for fcos 1.5.0-experimental,
+  flatcar 1.1.0-experimental, openshift 4.13.0-experimental)_
 
 ### Docs changes
 


### PR DESCRIPTION
They complicate the API without adding much value, and we use them inconsistently.  Followup to #53.