### PR TITLE
Bump minimum Go version to 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test build
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.18.x, 1.19.x]
         os: [ubuntu-latest]
         include:
         - go-version: 1.19.x

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,7 @@ nav_order: 9
 
 - Drop `LuksOption` and `RaidOption` types _(Go API for fcos 1.5.0-experimental,
   flatcar 1.1.0-experimental, openshift 4.13.0-experimental)_
+- Require Go 1.18+
 
 ### Docs changes
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/butane
 
-go 1.17
+go 1.18
 
 require (
 	github.com/clarketm/json v1.17.1


### PR DESCRIPTION
Go 1.17 is EOL.