### PR TITLE
openshift/v4_13_exp: allow `passwd.users.password_hash`

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -65,7 +65,7 @@ var (
 	ErrFileCompressionSupport = errors.New("file compression is not supported in this spec version")
 	ErrFileSpecialModeSupport = errors.New("special mode bits are not supported in this spec version")
 	ErrGroupSupport           = errors.New("groups are not supported in this spec version")
-	ErrUserFieldSupport       = errors.New("fields other than \"name\" and \"ssh_authorized_keys\" are not supported in this spec version")
+	ErrUserFieldSupport       = errors.New("fields other than \"name\", \"ssh_authorized_keys\", and \"password_hash\" (4.13.0+) are not supported in this spec version")
 	ErrUserNameSupport        = errors.New("users other than \"core\" are not supported in this spec version")
 	ErrKernelArgumentSupport  = errors.New("this field cannot be used for kernel arguments in this spec version; use openshift.kernel_arguments instead")
 

--- a/config/openshift/v4_13_exp/translate.go
+++ b/config/openshift/v4_13_exp/translate.go
@@ -264,14 +264,14 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 	}
 	for i, user := range mc.Spec.Config.Passwd.Users {
 		if user.Name == "core" {
-			// SSHAuthorizedKeys is managed; other fields are not
+			// PasswordHash and SSHAuthorizedKeys are managed; other fields are not
 			v := reflect.ValueOf(user)
 			t := v.Type()
 			for j := 0; j < v.NumField(); j++ {
 				fv := v.Field(j)
 				ft := t.Field(j)
 				switch ft.Name {
-				case "Name", "SSHAuthorizedKeys":
+				case "Name", "PasswordHash", "SSHAuthorizedKeys":
 					continue
 				default:
 					if fv.IsValid() && !fv.IsZero() {

--- a/config/openshift/v4_13_exp/translate_test.go
+++ b/config/openshift/v4_13_exp/translate_test.go
@@ -405,6 +405,7 @@ func TestValidateSupport(t *testing.T) {
 							Users: []base.PasswdUser{
 								{
 									Name:              "core",
+									PasswordHash:      util.StrToPtr("corned beef"),
 									SSHAuthorizedKeys: []base.SSHAuthorizedKey{"value"},
 								},
 							},
@@ -550,7 +551,6 @@ func TestValidateSupport(t *testing.T) {
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "no_create_home")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "no_log_init")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "no_user_group")},
-				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "password_hash")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "primary_group")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "shell")},
 				{report.Error, common.ErrUserFieldSupport, path.New("yaml", "passwd", "users", 0, "should_exist")},

--- a/docs/config-openshift-v4_13-exp.md
+++ b/docs/config-openshift-v4_13-exp.md
@@ -147,6 +147,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **_passwd_** (object): describes the desired additions to the passwd database.
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
+    * **_password_hash_** (string): the hashed password for the account.
     * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ nav_order: 9
   flatcar 1.1.0-exp, openshift 4.13.0-exp)_
 - Allow specifying arbitrary LUKS open options _(fcos 1.5.0-exp,
   flatcar 1.1.0-exp, openshift 4.13.0-exp)_
+- Allow specifying user password hash _(openshift 4.13.0-exp)_
 
 ### Bug fixes
 


### PR DESCRIPTION
The MCO added support in https://github.com/openshift/machine-config-operator/pull/3539.

Awkwardly add `"password_hash" (4.13.0+)` to the existing error string. The alternative is creating a new error code for 4.13+, which would produce a cleaner error message, but that would break any callers programmatically checking for `ErrUserFieldSupport`.

cc @jkyros