### PR TITLE
docs/config-openshift-*: document location of SSH keys in RHEL 9

### DIFF
--- a/docs/config-openshift-v4_10.md
+++ b/docs/config-openshift-v4_10.md
@@ -143,7 +143,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **_passwd_** (object): describes the desired additions to the passwd database.
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
-    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` (OpenShift < 4.13) or `.ssh/authorized_keys.d/ignition` (OpenShift ≥ 4.13) in the user's home directory. All SSH keys must be unique.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.

--- a/docs/config-openshift-v4_11.md
+++ b/docs/config-openshift-v4_11.md
@@ -143,7 +143,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **_passwd_** (object): describes the desired additions to the passwd database.
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
-    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` (OpenShift < 4.13) or `.ssh/authorized_keys.d/ignition` (OpenShift ≥ 4.13) in the user's home directory. All SSH keys must be unique.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.

--- a/docs/config-openshift-v4_12.md
+++ b/docs/config-openshift-v4_12.md
@@ -143,7 +143,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **_passwd_** (object): describes the desired additions to the passwd database.
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
-    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` (OpenShift < 4.13) or `.ssh/authorized_keys.d/ignition` (OpenShift ≥ 4.13) in the user's home directory. All SSH keys must be unique.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.

--- a/docs/config-openshift-v4_13-exp.md
+++ b/docs/config-openshift-v4_13-exp.md
@@ -149,7 +149,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
     * **_password_hash_** (string): the hashed password for the account.
-    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.

--- a/docs/config-openshift-v4_8.md
+++ b/docs/config-openshift-v4_8.md
@@ -141,7 +141,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **_passwd_** (object): describes the desired additions to the passwd database.
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
-    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` (OpenShift < 4.13) or `.ssh/authorized_keys.d/ignition` (OpenShift ≥ 4.13) in the user's home directory. All SSH keys must be unique.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.

--- a/docs/config-openshift-v4_9.md
+++ b/docs/config-openshift-v4_9.md
@@ -141,7 +141,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **_passwd_** (object): describes the desired additions to the passwd database.
   * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
     * **name** (string): the username for the account. Must be `core`.
-    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` in the user's home directory. All SSH keys must be unique.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added to `.ssh/authorized_keys` (OpenShift < 4.13) or `.ssh/authorized_keys.d/ignition` (OpenShift ≥ 4.13) in the user's home directory. All SSH keys must be unique.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
   * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -35,6 +35,7 @@ nav_order: 9
 
 - Document that `hash` fields describe decompressed data
 - Clarify spec docs for `files`/`luks` `hash` fields
+- Document SSH key file path used by OpenShift 4.13+ _(openshift)_
 
 
 ## Butane 0.17.0 (2023-01-04)


### PR DESCRIPTION
OpenShift 4.13+ puts SSH keys in `.ssh/authorized_keys.d/ignition`.  Switch the 4.13 spec doc to that path.  For older spec docs we need to mention both paths, since Ignition will use the new path on 4.13+ even if an older Butane spec is used.