### PR TITLE
internal: add `-c`/`--check` option to skip output

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ nav_order: 9
 
 ### Features
 
+- Add `-c`/`--check` option to check config without producing output
 
 ### Bug fixes
 

--- a/test
+++ b/test
@@ -65,7 +65,7 @@ if [ -n "${csplit}" ] && [ -n "${head}" ]; then
         do
             echo "Checking ${i}"
             tail -n +3 "${i}" | ${head} -n -1 \
-                | "${BIN_PATH}/${NAME}" --strict --files-dir tmpdocs/files-dir >/dev/null \
+                | "${BIN_PATH}/${NAME}" --check --strict --files-dir tmpdocs/files-dir \
                 || (cat -n "${i}" && false)
         done
         rm -f tmpdocs/config_*


### PR DESCRIPTION
Add option to validate config without producing Ignition or MachineConfig output.