### PR TITLE
templates/stabilize-checklist: note spec stabilization in release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/stabilize-checklist.md
+++ b/.github/ISSUE_TEMPLATE/stabilize-checklist.md
@@ -33,3 +33,4 @@ This checklist describes bumping the Ignition spec version, `base` version, and 
 - [ ] Rename the `C-exp` spec doc to `C`. Update the header, delete the experimental config warning, and update the version numbers in the description of the `version` field. Update the `nav_order` to one less than the previous stable release.
 - [ ] Update `docs/specs.md`.
 - [ ] Update `docs/upgrading-*.md` for the new spec version. Copy the relevant section from Ignition's `doc/migrating-configs.md`, convert the configs to Butane configs, convert field names to snake case, and update wording as needed. Add subsections for any new Butane-specific features.
+- [ ] Note the stabilization in `docs/release-notes.md`, following the format of previous stabilizations. Drop the `-exp` version suffix from any notes for the upcoming release.


### PR DESCRIPTION
Matches a similar checklist change in Ignition.