### PR TITLE
config: define error structs for errors that have context

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -16,6 +16,9 @@ package common
 
 import (
 	"errors"
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
 )
 
 var (
@@ -88,3 +91,22 @@ var (
 	// Kernel arguments
 	ErrGeneralKernelArgumentSupport = errors.New("kernel argument customization is not supported in this spec version")
 )
+
+type ErrUnmarshal struct {
+	// don't wrap the underlying error object because we don't want to
+	// commit to its API
+	Detail string
+}
+
+func (e ErrUnmarshal) Error() string {
+	return fmt.Sprintf("Error unmarshaling yaml: %v", e.Detail)
+}
+
+type ErrUnknownVersion struct {
+	Variant string
+	Version semver.Version
+}
+
+func (e ErrUnknownVersion) Error() string {
+	return fmt.Sprintf("No translator exists for variant %s with version %s", e.Variant, e.Version)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -92,7 +92,10 @@ func RegisterTranslator(variant, version string, trans translator) {
 func getTranslator(variant string, version semver.Version) (translator, error) {
 	t, ok := registry[fmt.Sprintf("%s+%s", variant, version.String())]
 	if !ok {
-		return nil, fmt.Errorf("No translator exists for variant %s with version %s", variant, version.String())
+		return nil, common.ErrUnknownVersion{
+			Variant: variant,
+			Version: version,
+		}
 	}
 	return t, nil
 }
@@ -108,7 +111,9 @@ func TranslateBytes(input []byte, options common.TranslateBytesOptions) ([]byte,
 	// first determine version; this will ignore most fields
 	ver := commonFields{}
 	if err := yaml.Unmarshal(input, &ver); err != nil {
-		return nil, report.Report{}, fmt.Errorf("Error unmarshaling yaml: %v", err)
+		return nil, report.Report{}, common.ErrUnmarshal{
+			Detail: err.Error(),
+		}
 	}
 
 	if ver.Variant == "" {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,7 @@ nav_order: 9
 
 ### Misc. changes
 
+- Add error structs for YAML unmarshal errors, unknown config versions (Go API)
 
 ### Docs changes
 


### PR DESCRIPTION
Butane has two sites that want to include additional information in an error string.  Rather than requiring callers to string-match to detect these, define structs with the error details.

This should not be a breaking change.