### PR TITLE
tests: verify that report paths are valid

### DIFF
--- a/base/util/test.go
+++ b/base/util/test.go
@@ -15,9 +15,15 @@
 package util
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,4 +46,103 @@ func VerifyTranslations(t *testing.T, set translate.TranslationSet, exceptions [
 			assert.Equal(t, translation.From.Path, translation.To.Path, "translation is not identity")
 		}
 	}
+}
+
+// VerifyTranslatedReport translates report paths from camelCase json to
+// snake_case yaml and then verifies that every path in a report corresponds
+// to a valid field in the object.
+func VerifyTranslatedReport(t *testing.T, obj interface{}, ts translate.TranslationSet, r report.Report) {
+	// check for stray snake_case
+	for _, entry := range r.Entries {
+		if entry.Context.Tag == "yaml" {
+			// expected to be in snake case
+			continue
+		}
+		for _, component := range entry.Context.Path {
+			str, ok := component.(string)
+			if !ok {
+				continue
+			}
+			if strings.Contains(str, "_") {
+				t.Errorf("%s: translated report contains snake_case name", entry.Context)
+			}
+		}
+	}
+
+	r2 := confutil.TranslateReportPaths(r, ts)
+	VerifyReport(t, obj, r2)
+}
+
+// VerifyReport verifies that every path in a report corresponds to a valid
+// field in the object.
+func VerifyReport(t *testing.T, obj interface{}, r report.Report) {
+	v := reflect.ValueOf(obj)
+	for _, entry := range r.Entries {
+		verifyPath(t, v, entry.Context)
+	}
+}
+
+func verifyPath(t *testing.T, v reflect.Value, p path.ContextPath) {
+	if len(p.Path) == 0 {
+		return
+	}
+	switch v.Kind() {
+	case reflect.Map:
+		value := v.MapIndex(reflect.ValueOf(p.Path[0]))
+		if v.IsZero() {
+			t.Errorf("%s: path component %q is nonexistent map key", p, p.Path[0])
+			return
+		}
+		verifyPath(t, value, p.Tail())
+	case reflect.Pointer:
+		if !v.IsValid() || v.IsNil() {
+			t.Errorf("%s: path component %q points through a nil pointer", p, p.Path[0])
+			return
+		}
+		verifyPath(t, v.Elem(), p)
+	case reflect.Slice:
+		index, ok := p.Path[0].(int)
+		if !ok {
+			t.Errorf("%s: path component %q is not a valid slice index", p, p.Path[0])
+			return
+		}
+		if index >= v.Len() {
+			t.Errorf("%s: path index %d out of bounds for slice of length %d", p, index, v.Len())
+			return
+		}
+		verifyPath(t, v.Index(index), p.Tail())
+	case reflect.Struct:
+		fieldName, ok := p.Path[0].(string)
+		if !ok {
+			t.Errorf("%s: path component %q is not a valid struct field name", p, p.Path[0])
+			return
+		}
+		if !verifyStruct(t, v, p, fieldName) {
+			t.Errorf("%s: path component %q refers to nonexistent field", p, p.Path[0])
+		}
+	default:
+		t.Errorf("%s: path component %q points through kind %s", p, p.Path[0], v.Kind())
+	}
+}
+
+func verifyStruct(t *testing.T, v reflect.Value, p path.ContextPath, fieldName string) bool {
+	if v.Kind() != reflect.Struct {
+		panic("verifyStruct called on non-struct")
+	}
+	for i := 0; i < v.NumField(); i++ {
+		fieldType := v.Type().Field(i)
+		if fieldType.Anonymous {
+			if verifyStruct(t, v.Field(i), p, fieldName) {
+				return true
+			}
+		} else {
+			tag := strings.Split(fieldType.Tag.Get("yaml"), ",")[0]
+			if tag == fieldName {
+				verifyPath(t, v.Field(i), p.Tail())
+				return true
+			}
+		}
+	}
+	// didn't find field
+	return false
 }

--- a/base/v0_1/translate_test.go
+++ b/base/v0_1/translate_test.go
@@ -134,6 +134,7 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -191,6 +192,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -249,6 +251,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -273,6 +276,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -303,6 +307,7 @@ func TestToIgn3_0(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_1/validate_test.go
+++ b/base/v0_1/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -71,6 +72,7 @@ func TestValidateFileContents(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			// hardcode inline for now since that's the only place errors occur. Move into the
 			// test struct once there's more than one place
@@ -106,6 +108,7 @@ func TestValidateFileMode(t *testing.T) {
 	for i, test := range fileTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -139,6 +142,7 @@ func TestValidateDirMode(t *testing.T) {
 	for i, test := range dirTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -541,6 +541,7 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -598,6 +599,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -656,6 +658,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -711,6 +714,7 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -894,6 +898,7 @@ RequiredBy=local-fs.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1420,6 +1425,7 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_1Unvalidated(options)
 
+			baseutil.VerifyTranslatedReport(t, config, translations, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1521,6 +1527,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1551,6 +1558,7 @@ func TestToIgn3_1(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_2/validate_test.go
+++ b/base/v0_2/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -130,6 +131,7 @@ func TestValidateResource(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -151,6 +153,7 @@ func TestValidateTree(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(path.New("yaml"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -184,6 +187,7 @@ func TestValidateFileMode(t *testing.T) {
 	for i, test := range fileTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -217,6 +221,7 @@ func TestValidateDirMode(t *testing.T) {
 	for i, test := range dirTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -541,6 +541,7 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -598,6 +599,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -656,6 +658,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -711,6 +714,7 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, in, translations, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1048,6 +1052,7 @@ RequiredBy=remote-fs.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1574,6 +1579,7 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_2Unvalidated(options)
 
+			baseutil.VerifyTranslatedReport(t, config, translations, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1675,6 +1681,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1705,6 +1712,7 @@ func TestToIgn3_2(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_3/validate_test.go
+++ b/base/v0_3/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -130,6 +131,7 @@ func TestValidateResource(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -151,6 +153,7 @@ func TestValidateTree(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(path.New("yaml"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -184,6 +187,7 @@ func TestValidateFileMode(t *testing.T) {
 	for i, test := range fileTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -217,6 +221,7 @@ func TestValidateDirMode(t *testing.T) {
 	for i, test := range dirTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -541,6 +541,7 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -598,6 +599,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -656,6 +658,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -711,6 +714,7 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, in, translations, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1133,6 +1137,7 @@ RequiredBy=swap.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1659,6 +1664,7 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_3Unvalidated(options)
 
+			baseutil.VerifyTranslatedReport(t, config, translations, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1760,6 +1766,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1809,6 +1816,7 @@ func TestTranslateKernelArguments(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -1835,6 +1843,7 @@ func TestToIgn3_3(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_4/validate_test.go
+++ b/base/v0_4/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -130,6 +131,7 @@ func TestValidateResource(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -151,6 +153,7 @@ func TestValidateTree(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(path.New("yaml"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -184,6 +187,7 @@ func TestValidateFileMode(t *testing.T) {
 	for i, test := range fileTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -217,6 +221,7 @@ func TestValidateDirMode(t *testing.T) {
 	for i, test := range dirTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -283,6 +288,7 @@ func TestValidateFilesystem(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/base/v0_5/translate_test.go
+++ b/base/v0_5/translate_test.go
@@ -541,6 +541,7 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -598,6 +599,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -656,6 +658,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -711,6 +714,7 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1133,6 +1137,7 @@ RequiredBy=swap.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1659,6 +1664,7 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_4Unvalidated(options)
 
+			baseutil.VerifyTranslatedReport(t, config, translations, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1760,6 +1766,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1809,6 +1816,7 @@ func TestTranslateKernelArguments(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -1882,6 +1890,7 @@ func TestTranslateTang(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -2094,6 +2103,7 @@ func TestTranslateSSHAuthorizedKey(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translatePasswdUser(test.in, common.TranslateOptions{FilesDir: test.fileDir})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2256,6 +2266,7 @@ func TestTranslateUnitLocal(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translateUnit(test.in, common.TranslateOptions{FilesDir: test.fileDir})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2283,6 +2294,7 @@ func TestToIgn3_4(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_5/validate_test.go
+++ b/base/v0_5/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -130,6 +131,7 @@ func TestValidateResource(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -151,6 +153,7 @@ func TestValidateTree(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(path.New("yaml"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -184,6 +187,7 @@ func TestValidateFileMode(t *testing.T) {
 	for i, test := range fileTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -217,6 +221,7 @@ func TestValidateDirMode(t *testing.T) {
 	for i, test := range dirTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -283,6 +288,7 @@ func TestValidateFilesystem(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -328,6 +334,7 @@ func TestValidateUnit(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -373,6 +380,7 @@ func TestValidateDropin(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/base/v0_6_exp/translate_test.go
+++ b/base/v0_6_exp/translate_test.go
@@ -541,6 +541,7 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -598,6 +599,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -656,6 +658,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -711,6 +714,7 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, in, translations, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1133,6 +1137,7 @@ RequiredBy=swap.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1659,6 +1664,7 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_5Unvalidated(options)
 
+			baseutil.VerifyTranslatedReport(t, config, translations, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1760,6 +1766,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1809,6 +1816,7 @@ func TestTranslateKernelArguments(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -1882,6 +1890,7 @@ func TestTranslateTang(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -2094,6 +2103,7 @@ func TestTranslateSSHAuthorizedKey(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translatePasswdUser(test.in, common.TranslateOptions{FilesDir: test.fileDir})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2256,6 +2266,7 @@ func TestTranslateUnitLocal(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translateUnit(test.in, common.TranslateOptions{FilesDir: test.fileDir})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2283,6 +2294,7 @@ func TestToIgn3_5(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_6_exp/validate_test.go
+++ b/base/v0_6_exp/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -130,6 +131,7 @@ func TestValidateResource(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -151,6 +153,7 @@ func TestValidateTree(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(path.New("yaml"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -184,6 +187,7 @@ func TestValidateFileMode(t *testing.T) {
 	for i, test := range fileTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -217,6 +221,7 @@ func TestValidateDirMode(t *testing.T) {
 	for i, test := range dirTests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnWarn(path.New("yaml", "mode"), test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -283,6 +288,7 @@ func TestValidateFilesystem(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -328,6 +334,7 @@ func TestValidateUnit(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -373,6 +380,7 @@ func TestValidateDropin(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/fcos/v1_0/translate_test.go
+++ b/config/fcos/v1_0/translate_test.go
@@ -145,6 +145,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_1/translate_test.go
+++ b/config/fcos/v1_1/translate_test.go
@@ -145,6 +145,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_2/translate_test.go
+++ b/config/fcos/v1_2/translate_test.go
@@ -148,6 +148,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_3/translate_test.go
+++ b/config/fcos/v1_3/translate_test.go
@@ -1413,6 +1413,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_3/validate_test.go
+++ b/config/fcos/v1_3/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_3"
 	"github.com/coreos/butane/config/common"
 
@@ -181,6 +182,7 @@ func TestValidateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad validation report")

--- a/config/fcos/v1_4/translate_test.go
+++ b/config/fcos/v1_4/translate_test.go
@@ -1413,6 +1413,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_4/validate_test.go
+++ b/config/fcos/v1_4/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_4"
 	"github.com/coreos/butane/config/common"
 
@@ -181,6 +182,7 @@ func TestValidateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad validation report")

--- a/config/fcos/v1_5/translate_test.go
+++ b/config/fcos/v1_5/translate_test.go
@@ -1495,6 +1495,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -1625,6 +1626,7 @@ func TestTranslateGrub(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_5/validate_test.go
+++ b/config/fcos/v1_5/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_5"
 	"github.com/coreos/butane/config/common"
 
@@ -181,6 +182,7 @@ func TestValidateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad validation report")
@@ -225,6 +227,7 @@ func TestValidateGrubUser(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/fcos/v1_6_exp/translate_test.go
+++ b/config/fcos/v1_6_exp/translate_test.go
@@ -1495,6 +1495,7 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -1625,6 +1626,7 @@ func TestTranslateGrub(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_6_exp/validate_test.go
+++ b/config/fcos/v1_6_exp/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_6_exp"
 	"github.com/coreos/butane/config/common"
 
@@ -181,6 +182,7 @@ func TestValidateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad validation report")
@@ -225,6 +227,7 @@ func TestValidateGrubUser(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/flatcar/v1_0/translate_test.go
+++ b/config/flatcar/v1_0/translate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_4"
 	"github.com/coreos/butane/config/common"
 
@@ -70,6 +71,7 @@ func TestTranslation(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/flatcar/v1_1/translate_test.go
+++ b/config/flatcar/v1_1/translate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_5"
 	"github.com/coreos/butane/config/common"
 
@@ -70,6 +71,7 @@ func TestTranslation(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/flatcar/v1_2_exp/translate_test.go
+++ b/config/flatcar/v1_2_exp/translate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_6_exp"
 	"github.com/coreos/butane/config/common"
 
@@ -70,6 +71,7 @@ func TestTranslation(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_10/translate_test.go
+++ b/config/openshift/v4_10/translate_test.go
@@ -276,6 +276,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -472,6 +473,7 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_10/validate.go
+++ b/config/openshift/v4_10/validate.go
@@ -26,7 +26,7 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
 	if m.Labels[ROLE_LABEL_KEY] == "" {
-		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+		r.AddOnError(c.Append("labels"), common.ErrRoleRequired)
 	}
 	return
 }

--- a/config/openshift/v4_10/validate_test.go
+++ b/config/openshift/v4_10/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -67,6 +68,7 @@ func TestValidateMetadata(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -99,6 +101,7 @@ func TestValidateOpenShift(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/openshift/v4_10/validate_test.go
+++ b/config/openshift/v4_10/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetadata(t *testing.T) {
 				Name: "n",
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 		// empty role
 		{
@@ -60,7 +60,7 @@ func TestValidateMetadata(t *testing.T) {
 				},
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 	}
 

--- a/config/openshift/v4_11/translate_test.go
+++ b/config/openshift/v4_11/translate_test.go
@@ -276,6 +276,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -472,6 +473,7 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_11/validate.go
+++ b/config/openshift/v4_11/validate.go
@@ -26,7 +26,7 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
 	if m.Labels[ROLE_LABEL_KEY] == "" {
-		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+		r.AddOnError(c.Append("labels"), common.ErrRoleRequired)
 	}
 	return
 }

--- a/config/openshift/v4_11/validate_test.go
+++ b/config/openshift/v4_11/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -67,6 +68,7 @@ func TestValidateMetadata(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -99,6 +101,7 @@ func TestValidateOpenShift(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/openshift/v4_11/validate_test.go
+++ b/config/openshift/v4_11/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetadata(t *testing.T) {
 				Name: "n",
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 		// empty role
 		{
@@ -60,7 +60,7 @@ func TestValidateMetadata(t *testing.T) {
 				},
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 	}
 

--- a/config/openshift/v4_12/translate_test.go
+++ b/config/openshift/v4_12/translate_test.go
@@ -276,6 +276,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_12Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -472,6 +473,7 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_12Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_12/validate.go
+++ b/config/openshift/v4_12/validate.go
@@ -26,7 +26,7 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
 	if m.Labels[ROLE_LABEL_KEY] == "" {
-		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+		r.AddOnError(c.Append("labels"), common.ErrRoleRequired)
 	}
 	return
 }

--- a/config/openshift/v4_12/validate_test.go
+++ b/config/openshift/v4_12/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -67,6 +68,7 @@ func TestValidateMetadata(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -99,6 +101,7 @@ func TestValidateOpenShift(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/openshift/v4_12/validate_test.go
+++ b/config/openshift/v4_12/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetadata(t *testing.T) {
 				Name: "n",
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 		// empty role
 		{
@@ -60,7 +60,7 @@ func TestValidateMetadata(t *testing.T) {
 				},
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 	}
 

--- a/config/openshift/v4_13/translate_test.go
+++ b/config/openshift/v4_13/translate_test.go
@@ -276,6 +276,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_13Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -472,6 +473,7 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_13Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_13/validate.go
+++ b/config/openshift/v4_13/validate.go
@@ -26,7 +26,7 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
 	if m.Labels[ROLE_LABEL_KEY] == "" {
-		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+		r.AddOnError(c.Append("labels"), common.ErrRoleRequired)
 	}
 	return
 }

--- a/config/openshift/v4_13/validate_test.go
+++ b/config/openshift/v4_13/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -67,6 +68,7 @@ func TestValidateMetadata(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -99,6 +101,7 @@ func TestValidateOpenShift(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/openshift/v4_13/validate_test.go
+++ b/config/openshift/v4_13/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetadata(t *testing.T) {
 				Name: "n",
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 		// empty role
 		{
@@ -60,7 +60,7 @@ func TestValidateMetadata(t *testing.T) {
 				},
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 	}
 

--- a/config/openshift/v4_14_exp/translate_test.go
+++ b/config/openshift/v4_14_exp/translate_test.go
@@ -359,6 +359,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_14Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -571,6 +572,7 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_14Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_14_exp/validate.go
+++ b/config/openshift/v4_14_exp/validate.go
@@ -26,7 +26,7 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
 	if m.Labels[ROLE_LABEL_KEY] == "" {
-		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+		r.AddOnError(c.Append("labels"), common.ErrRoleRequired)
 	}
 	return
 }

--- a/config/openshift/v4_14_exp/validate_test.go
+++ b/config/openshift/v4_14_exp/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -67,6 +68,7 @@ func TestValidateMetadata(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -99,6 +101,7 @@ func TestValidateOpenShift(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/openshift/v4_14_exp/validate_test.go
+++ b/config/openshift/v4_14_exp/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetadata(t *testing.T) {
 				Name: "n",
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 		// empty role
 		{
@@ -60,7 +60,7 @@ func TestValidateMetadata(t *testing.T) {
 				},
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 	}
 

--- a/config/openshift/v4_8/translate_test.go
+++ b/config/openshift/v4_8/translate_test.go
@@ -349,6 +349,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -548,6 +549,7 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_8/validate.go
+++ b/config/openshift/v4_8/validate.go
@@ -26,7 +26,7 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
 	if m.Labels[ROLE_LABEL_KEY] == "" {
-		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+		r.AddOnError(c.Append("labels"), common.ErrRoleRequired)
 	}
 	return
 }

--- a/config/openshift/v4_8/validate_test.go
+++ b/config/openshift/v4_8/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -67,6 +68,7 @@ func TestValidateMetadata(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -99,6 +101,7 @@ func TestValidateOpenShift(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/openshift/v4_8/validate_test.go
+++ b/config/openshift/v4_8/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetadata(t *testing.T) {
 				Name: "n",
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 		// empty role
 		{
@@ -60,7 +60,7 @@ func TestValidateMetadata(t *testing.T) {
 				},
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 	}
 

--- a/config/openshift/v4_9/translate_test.go
+++ b/config/openshift/v4_9/translate_test.go
@@ -349,6 +349,7 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -548,6 +549,7 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_9/validate.go
+++ b/config/openshift/v4_9/validate.go
@@ -26,7 +26,7 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
 	if m.Labels[ROLE_LABEL_KEY] == "" {
-		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+		r.AddOnError(c.Append("labels"), common.ErrRoleRequired)
 	}
 	return
 }

--- a/config/openshift/v4_9/validate_test.go
+++ b/config/openshift/v4_9/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -67,6 +68,7 @@ func TestValidateMetadata(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")
@@ -99,6 +101,7 @@ func TestValidateOpenShift(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("validate %d", i), func(t *testing.T) {
 			actual := test.in.Validate(path.New("yaml"))
+			baseutil.VerifyReport(t, test.in, actual)
 			expected := report.Report{}
 			expected.AddOnError(test.errPath, test.out)
 			assert.Equal(t, expected, actual, "bad report")

--- a/config/openshift/v4_9/validate_test.go
+++ b/config/openshift/v4_9/validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetadata(t *testing.T) {
 				Name: "n",
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 		// empty role
 		{
@@ -60,7 +60,7 @@ func TestValidateMetadata(t *testing.T) {
 				},
 			},
 			common.ErrRoleRequired,
-			path.New("yaml", "labels", ROLE_LABEL_KEY),
+			path.New("yaml", "labels"),
 		},
 	}
 

--- a/config/r4e/v1_0/translate.go
+++ b/config/r4e/v1_0/translate.go
@@ -43,22 +43,22 @@ func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Conf
 // provided
 func checkForForbiddenFields(t types.Config, r *report.Report) {
 	for i := range t.KernelArguments.ShouldExist {
-		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_exist", i), common.ErrGeneralKernelArgumentSupport)
+		r.AddOnError(path.New("json", "kernelArguments", "shouldExist", i), common.ErrGeneralKernelArgumentSupport)
 	}
 	for i := range t.KernelArguments.ShouldNotExist {
-		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_not_exist", i), common.ErrGeneralKernelArgumentSupport)
+		r.AddOnError(path.New("json", "kernelArguments", "shouldNotExist", i), common.ErrGeneralKernelArgumentSupport)
 	}
 	for i := range t.Storage.Disks {
-		r.AddOnError(path.New("path", "json", "storage", "disks", i), common.ErrDiskSupport)
+		r.AddOnError(path.New("json", "storage", "disks", i), common.ErrDiskSupport)
 	}
 	for i := range t.Storage.Filesystems {
-		r.AddOnError(path.New("path", "json", "storage", "filesystems", i), common.ErrFilesystemSupport)
+		r.AddOnError(path.New("json", "storage", "filesystems", i), common.ErrFilesystemSupport)
 	}
 	for i := range t.Storage.Luks {
-		r.AddOnError(path.New("path", "json", "storage", "luks", i), common.ErrLuksSupport)
+		r.AddOnError(path.New("json", "storage", "luks", i), common.ErrLuksSupport)
 	}
 	for i := range t.Storage.Raid {
-		r.AddOnError(path.New("path", "json", "storage", "raid", i), common.ErrRaidSupport)
+		r.AddOnError(path.New("json", "storage", "raid", i), common.ErrRaidSupport)
 	}
 }
 

--- a/config/r4e/v1_0/translate_test.go
+++ b/config/r4e/v1_0/translate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_4"
 	"github.com/coreos/butane/config/common"
 	"github.com/coreos/ignition/v2/config/util"
@@ -168,6 +169,7 @@ func TestTranslateInvalid(t *testing.T) {
 				expectedReport.AddOnError(entry.Path, entry.Err)
 			}
 			actual, translations, r := test.In.ToIgn3_3Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.In, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/r4e/v1_0/translate_test.go
+++ b/config/r4e/v1_0/translate_test.go
@@ -52,7 +52,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("path", "json", "kernel_arguments", "should_exist", 0),
+					path.New("json", "kernelArguments", "shouldExist", 0),
 				},
 			},
 		},
@@ -71,7 +71,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("path", "json", "kernel_arguments", "should_not_exist", 0),
+					path.New("json", "kernelArguments", "shouldNotExist", 0),
 				},
 			},
 		},
@@ -92,7 +92,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrDiskSupport,
-					path.New("path", "json", "storage", "disks", 0),
+					path.New("json", "storage", "disks", 0),
 				},
 			},
 		},
@@ -114,7 +114,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrFilesystemSupport,
-					path.New("path", "json", "storage", "filesystems", 0),
+					path.New("json", "storage", "filesystems", 0),
 				},
 			},
 		},
@@ -135,7 +135,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrLuksSupport,
-					path.New("path", "json", "storage", "luks", 0),
+					path.New("json", "storage", "luks", 0),
 				},
 			},
 		},
@@ -156,7 +156,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrRaidSupport,
-					path.New("path", "json", "storage", "raid", 0),
+					path.New("json", "storage", "raid", 0),
 				},
 			},
 		},

--- a/config/r4e/v1_1/translate.go
+++ b/config/r4e/v1_1/translate.go
@@ -42,22 +42,22 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 // provided
 func checkForForbiddenFields(t types.Config, r *report.Report) {
 	for i := range t.KernelArguments.ShouldExist {
-		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_exist", i), common.ErrGeneralKernelArgumentSupport)
+		r.AddOnError(path.New("json", "kernelArguments", "shouldExist", i), common.ErrGeneralKernelArgumentSupport)
 	}
 	for i := range t.KernelArguments.ShouldNotExist {
-		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_not_exist", i), common.ErrGeneralKernelArgumentSupport)
+		r.AddOnError(path.New("json", "kernelArguments", "shouldNotExist", i), common.ErrGeneralKernelArgumentSupport)
 	}
 	for i := range t.Storage.Disks {
-		r.AddOnError(path.New("path", "json", "storage", "disks", i), common.ErrDiskSupport)
+		r.AddOnError(path.New("json", "storage", "disks", i), common.ErrDiskSupport)
 	}
 	for i := range t.Storage.Filesystems {
-		r.AddOnError(path.New("path", "json", "storage", "filesystems", i), common.ErrFilesystemSupport)
+		r.AddOnError(path.New("json", "storage", "filesystems", i), common.ErrFilesystemSupport)
 	}
 	for i := range t.Storage.Luks {
-		r.AddOnError(path.New("path", "json", "storage", "luks", i), common.ErrLuksSupport)
+		r.AddOnError(path.New("json", "storage", "luks", i), common.ErrLuksSupport)
 	}
 	for i := range t.Storage.Raid {
-		r.AddOnError(path.New("path", "json", "storage", "raid", i), common.ErrRaidSupport)
+		r.AddOnError(path.New("json", "storage", "raid", i), common.ErrRaidSupport)
 	}
 }
 

--- a/config/r4e/v1_1/translate_test.go
+++ b/config/r4e/v1_1/translate_test.go
@@ -52,7 +52,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("path", "json", "kernel_arguments", "should_exist", 0),
+					path.New("json", "kernelArguments", "shouldExist", 0),
 				},
 			},
 		},
@@ -71,7 +71,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("path", "json", "kernel_arguments", "should_not_exist", 0),
+					path.New("json", "kernelArguments", "shouldNotExist", 0),
 				},
 			},
 		},
@@ -92,7 +92,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrDiskSupport,
-					path.New("path", "json", "storage", "disks", 0),
+					path.New("json", "storage", "disks", 0),
 				},
 			},
 		},
@@ -114,7 +114,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrFilesystemSupport,
-					path.New("path", "json", "storage", "filesystems", 0),
+					path.New("json", "storage", "filesystems", 0),
 				},
 			},
 		},
@@ -135,7 +135,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrLuksSupport,
-					path.New("path", "json", "storage", "luks", 0),
+					path.New("json", "storage", "luks", 0),
 				},
 			},
 		},
@@ -156,7 +156,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrRaidSupport,
-					path.New("path", "json", "storage", "raid", 0),
+					path.New("json", "storage", "raid", 0),
 				},
 			},
 		},

--- a/config/r4e/v1_1/translate_test.go
+++ b/config/r4e/v1_1/translate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_5"
 	"github.com/coreos/butane/config/common"
 	"github.com/coreos/ignition/v2/config/util"
@@ -168,6 +169,7 @@ func TestTranslateInvalid(t *testing.T) {
 				expectedReport.AddOnError(entry.Path, entry.Err)
 			}
 			actual, translations, r := test.In.ToIgn3_4Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.In, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/r4e/v1_2_exp/translate.go
+++ b/config/r4e/v1_2_exp/translate.go
@@ -42,22 +42,22 @@ func (c Config) ToIgn3_5Unvalidated(options common.TranslateOptions) (types.Conf
 // provided
 func checkForForbiddenFields(t types.Config, r *report.Report) {
 	for i := range t.KernelArguments.ShouldExist {
-		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_exist", i), common.ErrGeneralKernelArgumentSupport)
+		r.AddOnError(path.New("json", "kernelArguments", "shouldExist", i), common.ErrGeneralKernelArgumentSupport)
 	}
 	for i := range t.KernelArguments.ShouldNotExist {
-		r.AddOnError(path.New("path", "json", "kernel_arguments", "should_not_exist", i), common.ErrGeneralKernelArgumentSupport)
+		r.AddOnError(path.New("json", "kernelArguments", "shouldNotExist", i), common.ErrGeneralKernelArgumentSupport)
 	}
 	for i := range t.Storage.Disks {
-		r.AddOnError(path.New("path", "json", "storage", "disks", i), common.ErrDiskSupport)
+		r.AddOnError(path.New("json", "storage", "disks", i), common.ErrDiskSupport)
 	}
 	for i := range t.Storage.Filesystems {
-		r.AddOnError(path.New("path", "json", "storage", "filesystems", i), common.ErrFilesystemSupport)
+		r.AddOnError(path.New("json", "storage", "filesystems", i), common.ErrFilesystemSupport)
 	}
 	for i := range t.Storage.Luks {
-		r.AddOnError(path.New("path", "json", "storage", "luks", i), common.ErrLuksSupport)
+		r.AddOnError(path.New("json", "storage", "luks", i), common.ErrLuksSupport)
 	}
 	for i := range t.Storage.Raid {
-		r.AddOnError(path.New("path", "json", "storage", "raid", i), common.ErrRaidSupport)
+		r.AddOnError(path.New("json", "storage", "raid", i), common.ErrRaidSupport)
 	}
 }
 

--- a/config/r4e/v1_2_exp/translate_test.go
+++ b/config/r4e/v1_2_exp/translate_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_6_exp"
 	"github.com/coreos/butane/config/common"
 	"github.com/coreos/ignition/v2/config/util"
@@ -168,6 +169,7 @@ func TestTranslateInvalid(t *testing.T) {
 				expectedReport.AddOnError(entry.Path, entry.Err)
 			}
 			actual, translations, r := test.In.ToIgn3_5Unvalidated(common.TranslateOptions{})
+			baseutil.VerifyTranslatedReport(t, test.In, translations, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/r4e/v1_2_exp/translate_test.go
+++ b/config/r4e/v1_2_exp/translate_test.go
@@ -52,7 +52,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("path", "json", "kernel_arguments", "should_exist", 0),
+					path.New("json", "kernelArguments", "shouldExist", 0),
 				},
 			},
 		},
@@ -71,7 +71,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("path", "json", "kernel_arguments", "should_not_exist", 0),
+					path.New("json", "kernelArguments", "shouldNotExist", 0),
 				},
 			},
 		},
@@ -92,7 +92,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrDiskSupport,
-					path.New("path", "json", "storage", "disks", 0),
+					path.New("json", "storage", "disks", 0),
 				},
 			},
 		},
@@ -114,7 +114,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrFilesystemSupport,
-					path.New("path", "json", "storage", "filesystems", 0),
+					path.New("json", "storage", "filesystems", 0),
 				},
 			},
 		},
@@ -135,7 +135,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrLuksSupport,
-					path.New("path", "json", "storage", "luks", 0),
+					path.New("json", "storage", "luks", 0),
 				},
 			},
 		},
@@ -156,7 +156,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrRaidSupport,
-					path.New("path", "json", "storage", "raid", 0),
+					path.New("json", "storage", "raid", 0),
 				},
 			},
 		},

--- a/config/util/util.go
+++ b/config/util/util.go
@@ -217,13 +217,17 @@ func snake(in string) string {
 	return strings.ToLower(snakeRe.ReplaceAllString(in, "_$1"))
 }
 
-// TranslateReportPaths takes a report from a camelCase json document and a set of translations rules,
-// applies those rules and converts all camelCase to snake_case.
+// TranslateReportPaths takes a report with a mix of json (camelCase) and
+// yaml (snake_case) paths, and a set of translation rules.  It applies
+// those rules and converts all json paths to snake-cased yaml.
 func TranslateReportPaths(r report.Report, ts translate.TranslationSet) report.Report {
 	var ret report.Report
 	ret.Merge(r)
 	for i, ent := range ret.Entries {
 		context := ent.Context
+		if context.Tag == "yaml" {
+			continue
+		}
 		if t, ok := ts.Set[context.String()]; ok {
 			context = t.From
 		} else {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Fix line/column reporting for unsupported field errors _(r4e)_
 
 ### Misc. changes
 


### PR DESCRIPTION
A common mistake is to create `ContextPaths` that aren't valid references to an item in the config.  `DebugVerifyCoverage()` should catch such paths in a `TranslationSet`, but validation errors (during either the validation or translation passes) may add paths to a report without a corresponding `TranslationSet` entry.  Add helper functions to validate paths in a report, and use them in every test case.

In particular, call the helpers even in tests that expect empty reports, to reduce the risk that a test created in the future will omit the check.

Fix context paths for forbidden field errors in all versions of the `r4e` spec.