### PR TITLE
Really fix line/column reporting for `r4e` unsupported field errors

### DIFF
--- a/base/util/test.go
+++ b/base/util/test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/vcontext/path"
@@ -46,31 +45,6 @@ func VerifyTranslations(t *testing.T, set translate.TranslationSet, exceptions [
 			assert.Equal(t, translation.From.Path, translation.To.Path, "translation is not identity")
 		}
 	}
-}
-
-// VerifyTranslatedReport translates report paths from camelCase json to
-// snake_case yaml and then verifies that every path in a report corresponds
-// to a valid field in the object.
-func VerifyTranslatedReport(t *testing.T, obj interface{}, ts translate.TranslationSet, r report.Report) {
-	// check for stray snake_case
-	for _, entry := range r.Entries {
-		if entry.Context.Tag == "yaml" {
-			// expected to be in snake case
-			continue
-		}
-		for _, component := range entry.Context.Path {
-			str, ok := component.(string)
-			if !ok {
-				continue
-			}
-			if strings.Contains(str, "_") {
-				t.Errorf("%s: translated report contains snake_case name", entry.Context)
-			}
-		}
-	}
-
-	r2 := confutil.TranslateReportPaths(r, ts)
-	VerifyReport(t, obj, r2)
 }
 
 // VerifyReport verifies that every path in a report corresponds to a valid

--- a/base/v0_1/translate_test.go
+++ b/base/v0_1/translate_test.go
@@ -20,6 +20,7 @@ import (
 
 	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -134,7 +135,8 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -192,7 +194,8 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -251,7 +254,8 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -276,7 +280,8 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -307,7 +312,8 @@ func TestToIgn3_0(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -26,6 +26,7 @@ import (
 
 	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -541,7 +542,8 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -599,7 +601,8 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -658,7 +661,8 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -714,7 +718,8 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -898,7 +903,8 @@ RequiredBy=local-fs.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1425,7 +1431,8 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_1Unvalidated(options)
 
-			baseutil.VerifyTranslatedReport(t, config, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, config, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1527,7 +1534,8 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1558,7 +1566,8 @@ func TestToIgn3_1(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -26,6 +26,7 @@ import (
 
 	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -541,7 +542,8 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -599,7 +601,8 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -658,7 +661,8 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -714,7 +718,8 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1052,7 +1057,8 @@ RequiredBy=remote-fs.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1579,7 +1585,8 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_2Unvalidated(options)
 
-			baseutil.VerifyTranslatedReport(t, config, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, config, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1681,7 +1688,8 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1712,7 +1720,8 @@ func TestToIgn3_2(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -26,6 +26,7 @@ import (
 
 	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -541,7 +542,8 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -599,7 +601,8 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -658,7 +661,8 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -714,7 +718,8 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1137,7 +1142,8 @@ RequiredBy=swap.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1664,7 +1670,8 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_3Unvalidated(options)
 
-			baseutil.VerifyTranslatedReport(t, config, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, config, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1766,7 +1773,8 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1816,7 +1824,8 @@ func TestTranslateKernelArguments(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -1843,7 +1852,8 @@ func TestToIgn3_3(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_5/translate_test.go
+++ b/base/v0_5/translate_test.go
@@ -26,6 +26,7 @@ import (
 
 	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -541,7 +542,8 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -599,7 +601,8 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -658,7 +661,8 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -714,7 +718,8 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1137,7 +1142,8 @@ RequiredBy=swap.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1664,7 +1670,8 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_4Unvalidated(options)
 
-			baseutil.VerifyTranslatedReport(t, config, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, config, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1766,7 +1773,8 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1816,7 +1824,8 @@ func TestTranslateKernelArguments(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -1890,7 +1899,8 @@ func TestTranslateTang(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -2103,7 +2113,8 @@ func TestTranslateSSHAuthorizedKey(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translatePasswdUser(test.in, common.TranslateOptions{FilesDir: test.fileDir})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2266,7 +2277,8 @@ func TestTranslateUnitLocal(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translateUnit(test.in, common.TranslateOptions{FilesDir: test.fileDir})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2294,7 +2306,8 @@ func TestToIgn3_4(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/base/v0_6_exp/translate_test.go
+++ b/base/v0_6_exp/translate_test.go
@@ -26,6 +26,7 @@ import (
 
 	baseutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -541,7 +542,8 @@ func TestTranslateFile(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateFile(test.in, test.options)
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -599,7 +601,8 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateDirectory(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -658,7 +661,8 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateLink(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -714,7 +718,8 @@ func TestTranslateFilesystem(t *testing.T) {
 			}
 			expected := []types.Filesystem{test.out}
 			actual, translations, r := in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expected, actual.Storage.Filesystems, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// FIXME: Zero values are pruned from merge transcripts and
@@ -1137,7 +1142,8 @@ RequiredBy=swap.target`),
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			out, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, out, "bad output")
 			assert.Equal(t, report.Report{}, r, "expected empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(out), "incomplete TranslationSet coverage")
@@ -1664,7 +1670,8 @@ func TestTranslateTree(t *testing.T) {
 			}
 			actual, translations, r := config.ToIgn3_5Unvalidated(options)
 
-			baseutil.VerifyTranslatedReport(t, config, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, config, r)
 			expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
 			assert.Equal(t, expectedReport, r.String(), "bad report")
 			if expectedReport != "" {
@@ -1766,7 +1773,8 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := translateIgnition(test.in, common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			// DebugVerifyCoverage wants to see a translation for $.version but
@@ -1816,7 +1824,8 @@ func TestTranslateKernelArguments(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -1890,7 +1899,8 @@ func TestTranslateTang(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
@@ -2103,7 +2113,8 @@ func TestTranslateSSHAuthorizedKey(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translatePasswdUser(test.in, common.TranslateOptions{FilesDir: test.fileDir})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2266,7 +2277,8 @@ func TestTranslateUnitLocal(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, translations, r := translateUnit(test.in, common.TranslateOptions{FilesDir: test.fileDir})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r.String(), "bad report")
 			baseutil.VerifyTranslations(t, translations, test.translations)
@@ -2294,7 +2306,8 @@ func TestToIgn3_5(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")

--- a/config/fcos/v1_0/translate_test.go
+++ b/config/fcos/v1_0/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_1"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -136,7 +137,7 @@ func TestTranslateConfig(t *testing.T) {
 					{
 						Kind:    report.Warn,
 						Message: common.ErrWrongPartitionNumber.Error(),
-						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
 					},
 				},
 			},
@@ -145,7 +146,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_1/translate_test.go
+++ b/config/fcos/v1_1/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_2"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -136,7 +137,7 @@ func TestTranslateConfig(t *testing.T) {
 					{
 						Kind:    report.Warn,
 						Message: common.ErrWrongPartitionNumber.Error(),
-						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
 					},
 				},
 			},
@@ -145,7 +146,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_2/translate_test.go
+++ b/config/fcos/v1_2/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_3"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -139,7 +140,7 @@ func TestTranslateConfig(t *testing.T) {
 					{
 						Kind:    report.Warn,
 						Message: common.ErrWrongPartitionNumber.Error(),
-						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
 					},
 				},
 			},
@@ -148,7 +149,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_3/translate_test.go
+++ b/config/fcos/v1_3/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_3"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -141,7 +142,7 @@ func TestTranslateBootDevice(t *testing.T) {
 					{
 						Kind:    report.Warn,
 						Message: common.ErrWrongPartitionNumber.Error(),
-						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
 					},
 				},
 			},
@@ -1413,7 +1414,8 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_4/translate_test.go
+++ b/config/fcos/v1_4/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_4"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -141,7 +142,7 @@ func TestTranslateBootDevice(t *testing.T) {
 					{
 						Kind:    report.Warn,
 						Message: common.ErrWrongPartitionNumber.Error(),
-						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
 					},
 				},
 			},
@@ -1413,7 +1414,8 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_5/translate_test.go
+++ b/config/fcos/v1_5/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_5"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -141,7 +142,7 @@ func TestTranslateBootDevice(t *testing.T) {
 					{
 						Kind:    report.Warn,
 						Message: common.ErrWrongPartitionNumber.Error(),
-						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
 					},
 				},
 			},
@@ -1495,7 +1496,8 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -1626,7 +1628,8 @@ func TestTranslateGrub(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/fcos/v1_6_exp/translate_test.go
+++ b/config/fcos/v1_6_exp/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_6_exp"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -141,7 +142,7 @@ func TestTranslateBootDevice(t *testing.T) {
 					{
 						Kind:    report.Warn,
 						Message: common.ErrWrongPartitionNumber.Error(),
-						Context: path.New("json", "storage", "disks", 0, "partitions", 0, "label"),
+						Context: path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"),
 					},
 				},
 			},
@@ -1495,7 +1496,8 @@ func TestTranslateBootDevice(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -1626,7 +1628,8 @@ func TestTranslateGrub(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, test.report, r, "report mismatch")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)

--- a/config/flatcar/v1_0/translate_test.go
+++ b/config/flatcar/v1_0/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_4"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
@@ -59,7 +60,7 @@ func TestTranslation(t *testing.T) {
 				},
 			},
 			[]entry{
-				{report.Error, common.ErrClevisSupport, path.New("json", "storage", "luks", 1, "clevis")},
+				{report.Error, common.ErrClevisSupport, path.New("yaml", "storage", "luks", 1, "clevis")},
 			},
 		},
 	}
@@ -71,7 +72,8 @@ func TestTranslation(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/flatcar/v1_1/translate_test.go
+++ b/config/flatcar/v1_1/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_5"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
@@ -59,7 +60,7 @@ func TestTranslation(t *testing.T) {
 				},
 			},
 			[]entry{
-				{report.Error, common.ErrClevisSupport, path.New("json", "storage", "luks", 1, "clevis")},
+				{report.Error, common.ErrClevisSupport, path.New("yaml", "storage", "luks", 1, "clevis")},
 			},
 		},
 	}
@@ -71,7 +72,8 @@ func TestTranslation(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/flatcar/v1_2_exp/translate_test.go
+++ b/config/flatcar/v1_2_exp/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_6_exp"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
@@ -59,7 +60,7 @@ func TestTranslation(t *testing.T) {
 				},
 			},
 			[]entry{
-				{report.Error, common.ErrClevisSupport, path.New("json", "storage", "luks", 1, "clevis")},
+				{report.Error, common.ErrClevisSupport, path.New("yaml", "storage", "luks", 1, "clevis")},
 			},
 		},
 	}
@@ -71,7 +72,8 @@ func TestTranslation(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_10/translate.go
+++ b/config/openshift/v4_10/translate.go
@@ -87,8 +87,8 @@ func (c Config) ToMachineConfig4_10Unvalidated(options common.TranslateOptions) 
 	ts.Merge(addLuksFipsOptions(&mc))
 
 	// finally, check the fully desugared config for RHCOS and MCO support
-	r.Merge(validateRHCOSSupport(mc, ts))
-	r.Merge(validateMCOSupport(mc, ts))
+	r.Merge(validateRHCOSSupport(mc))
+	r.Merge(validateMCOSupport(mc))
 
 	return mc, ts, r
 }
@@ -114,7 +114,8 @@ func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Conf
 	// than the Ignition config itself) that we're ignoring
 	mc.Spec.Config = types.Config{}
 	warnings := translate.PrefixReport(cutil.CheckForElidedFields(mc.Spec), "spec")
-	// translate from json space into yaml space
+	// translate from json space into yaml space, since the caller won't
+	// have enough info to do it
 	r.Merge(cutil.TranslateReportPaths(warnings, ts))
 
 	ts = ts.Descend(path.New("json", "spec", "config"))
@@ -177,7 +178,7 @@ OUTER:
 // boot_device.luks), so we work in JSON (output) space and then translate
 // paths back to YAML (input) space.  That's also the reason we do these
 // checks after translation, rather than during validation.
-func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateRHCOSSupport(mc result.MachineConfig) report.Report {
 	var r report.Report
 	for i, fs := range mc.Spec.Config.Storage.Filesystems {
 		if fs.Format != nil && *fs.Format == "btrfs" {
@@ -185,7 +186,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrBtrfsSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }
 
 // Error on fields that are rejected outright by the MCO, or that are
@@ -197,7 +198,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 // so we work in JSON (output) space and then translate paths back to YAML
 // (input) space.  That's also the reason we do these checks after
 // translation, rather than during validation.
-func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateMCOSupport(mc result.MachineConfig) report.Report {
 	// Error classes for the purposes of this function:
 	//
 	// UNPARSABLE - Cannot be rendered into a config by the MCC.  If
@@ -275,5 +276,5 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }

--- a/config/openshift/v4_10/translate_test.go
+++ b/config/openshift/v4_10/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/butane/config/common"
 	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_10/result"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -276,7 +277,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -473,7 +475,8 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_10Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_11/translate_test.go
+++ b/config/openshift/v4_11/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/butane/config/common"
 	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_11/result"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -276,7 +277,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -473,7 +475,8 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_11Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_12/translate.go
+++ b/config/openshift/v4_12/translate.go
@@ -87,8 +87,8 @@ func (c Config) ToMachineConfig4_12Unvalidated(options common.TranslateOptions) 
 	ts.Merge(addLuksFipsOptions(&mc))
 
 	// finally, check the fully desugared config for RHCOS and MCO support
-	r.Merge(validateRHCOSSupport(mc, ts))
-	r.Merge(validateMCOSupport(mc, ts))
+	r.Merge(validateRHCOSSupport(mc))
+	r.Merge(validateMCOSupport(mc))
 
 	return mc, ts, r
 }
@@ -114,7 +114,8 @@ func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Conf
 	// than the Ignition config itself) that we're ignoring
 	mc.Spec.Config = types.Config{}
 	warnings := translate.PrefixReport(cutil.CheckForElidedFields(mc.Spec), "spec")
-	// translate from json space into yaml space
+	// translate from json space into yaml space, since the caller won't
+	// have enough info to do it
 	r.Merge(cutil.TranslateReportPaths(warnings, ts))
 
 	ts = ts.Descend(path.New("json", "spec", "config"))
@@ -177,7 +178,7 @@ OUTER:
 // boot_device.luks), so we work in JSON (output) space and then translate
 // paths back to YAML (input) space.  That's also the reason we do these
 // checks after translation, rather than during validation.
-func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateRHCOSSupport(mc result.MachineConfig) report.Report {
 	var r report.Report
 	for i, fs := range mc.Spec.Config.Storage.Filesystems {
 		if fs.Format != nil && *fs.Format == "btrfs" {
@@ -185,7 +186,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrBtrfsSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }
 
 // Error on fields that are rejected outright by the MCO, or that are
@@ -197,7 +198,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 // so we work in JSON (output) space and then translate paths back to YAML
 // (input) space.  That's also the reason we do these checks after
 // translation, rather than during validation.
-func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateMCOSupport(mc result.MachineConfig) report.Report {
 	// Error classes for the purposes of this function:
 	//
 	// UNPARSABLE - Cannot be rendered into a config by the MCC.  If
@@ -275,5 +276,5 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }

--- a/config/openshift/v4_12/translate_test.go
+++ b/config/openshift/v4_12/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/butane/config/common"
 	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_12/result"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -276,7 +277,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_12Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -473,7 +475,8 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_12Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_13/translate.go
+++ b/config/openshift/v4_13/translate.go
@@ -87,8 +87,8 @@ func (c Config) ToMachineConfig4_13Unvalidated(options common.TranslateOptions) 
 	ts.Merge(addLuksFipsOptions(&mc))
 
 	// finally, check the fully desugared config for RHCOS and MCO support
-	r.Merge(validateRHCOSSupport(mc, ts))
-	r.Merge(validateMCOSupport(mc, ts))
+	r.Merge(validateRHCOSSupport(mc))
+	r.Merge(validateMCOSupport(mc))
 
 	return mc, ts, r
 }
@@ -114,7 +114,8 @@ func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Conf
 	// than the Ignition config itself) that we're ignoring
 	mc.Spec.Config = types.Config{}
 	warnings := translate.PrefixReport(cutil.CheckForElidedFields(mc.Spec), "spec")
-	// translate from json space into yaml space
+	// translate from json space into yaml space, since the caller won't
+	// have enough info to do it
 	r.Merge(cutil.TranslateReportPaths(warnings, ts))
 
 	ts = ts.Descend(path.New("json", "spec", "config"))
@@ -177,7 +178,7 @@ OUTER:
 // boot_device.luks), so we work in JSON (output) space and then translate
 // paths back to YAML (input) space.  That's also the reason we do these
 // checks after translation, rather than during validation.
-func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateRHCOSSupport(mc result.MachineConfig) report.Report {
 	var r report.Report
 	for i, fs := range mc.Spec.Config.Storage.Filesystems {
 		if fs.Format != nil && *fs.Format == "btrfs" {
@@ -185,7 +186,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrBtrfsSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }
 
 // Error on fields that are rejected outright by the MCO, or that are
@@ -197,7 +198,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 // so we work in JSON (output) space and then translate paths back to YAML
 // (input) space.  That's also the reason we do these checks after
 // translation, rather than during validation.
-func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateMCOSupport(mc result.MachineConfig) report.Report {
 	// Error classes for the purposes of this function:
 	//
 	// UNPARSABLE - Cannot be rendered into a config by the MCC.  If
@@ -275,5 +276,5 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }

--- a/config/openshift/v4_13/translate_test.go
+++ b/config/openshift/v4_13/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/butane/config/common"
 	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_13/result"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -276,7 +277,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_13Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -473,7 +475,8 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_13Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_14_exp/translate.go
+++ b/config/openshift/v4_14_exp/translate.go
@@ -88,8 +88,8 @@ func (c Config) ToMachineConfig4_14Unvalidated(options common.TranslateOptions) 
 	ts.Merge(addLuksFipsOptions(&mc))
 
 	// finally, check the fully desugared config for RHCOS and MCO support
-	r.Merge(validateRHCOSSupport(mc, ts))
-	r.Merge(validateMCOSupport(mc, ts))
+	r.Merge(validateRHCOSSupport(mc))
+	r.Merge(validateMCOSupport(mc))
 
 	return mc, ts, r
 }
@@ -115,7 +115,8 @@ func (c Config) ToIgn3_5Unvalidated(options common.TranslateOptions) (types.Conf
 	// than the Ignition config itself) that we're ignoring
 	mc.Spec.Config = types.Config{}
 	warnings := translate.PrefixReport(cutil.CheckForElidedFields(mc.Spec), "spec")
-	// translate from json space into yaml space
+	// translate from json space into yaml space, since the caller won't
+	// have enough info to do it
 	r.Merge(cutil.TranslateReportPaths(warnings, ts))
 
 	ts = ts.Descend(path.New("json", "spec", "config"))
@@ -178,7 +179,7 @@ OUTER:
 // boot_device.luks), so we work in JSON (output) space and then translate
 // paths back to YAML (input) space.  That's also the reason we do these
 // checks after translation, rather than during validation.
-func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateRHCOSSupport(mc result.MachineConfig) report.Report {
 	var r report.Report
 	for i, fs := range mc.Spec.Config.Storage.Filesystems {
 		if fs.Format != nil && *fs.Format == "btrfs" {
@@ -186,7 +187,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrBtrfsSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }
 
 // Error on fields that are rejected outright by the MCO, or that are
@@ -198,7 +199,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 // so we work in JSON (output) space and then translate paths back to YAML
 // (input) space.  That's also the reason we do these checks after
 // translation, rather than during validation.
-func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateMCOSupport(mc result.MachineConfig) report.Report {
 	// Error classes for the purposes of this function:
 	//
 	// UNPARSABLE - Cannot be rendered into a config by the MCC.  If
@@ -294,7 +295,7 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 		// UNPARSABLE, REDUNDANT
 		r.AddOnError(path.New("json", "spec", "config", "kernelArguments", "shouldNotExist", i), common.ErrKernelArgumentSupport)
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }
 
 // fcos config generates a user.cfg file using append; however, OpenShift config

--- a/config/openshift/v4_14_exp/translate_test.go
+++ b/config/openshift/v4_14_exp/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/butane/config/common"
 	fcos "github.com/coreos/butane/config/fcos/v1_6_exp"
 	"github.com/coreos/butane/config/openshift/v4_14_exp/result"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -359,7 +360,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_14Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -572,7 +574,8 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_14Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_8/translate.go
+++ b/config/openshift/v4_8/translate.go
@@ -91,8 +91,8 @@ func (c Config) ToMachineConfig4_8Unvalidated(options common.TranslateOptions) (
 	ts.Merge(addLuksFipsOptions(&mc))
 
 	// finally, check the fully desugared config for RHCOS and MCO support
-	r.Merge(validateRHCOSSupport(mc, ts))
-	r.Merge(validateMCOSupport(mc, ts))
+	r.Merge(validateRHCOSSupport(mc))
+	r.Merge(validateMCOSupport(mc))
 
 	return mc, ts, r
 }
@@ -118,7 +118,8 @@ func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Conf
 	// than the Ignition config itself) that we're ignoring
 	mc.Spec.Config = types.Config{}
 	warnings := translate.PrefixReport(cutil.CheckForElidedFields(mc.Spec), "spec")
-	// translate from json space into yaml space
+	// translate from json space into yaml space, since the caller won't
+	// have enough info to do it
 	r.Merge(cutil.TranslateReportPaths(warnings, ts))
 
 	ts = ts.Descend(path.New("json", "spec", "config"))
@@ -181,7 +182,7 @@ OUTER:
 // boot_device.luks), so we work in JSON (output) space and then translate
 // paths back to YAML (input) space.  That's also the reason we do these
 // checks after translation, rather than during validation.
-func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateRHCOSSupport(mc result.MachineConfig) report.Report {
 	var r report.Report
 	for i, fs := range mc.Spec.Config.Storage.Filesystems {
 		if fs.Format != nil && *fs.Format == "btrfs" {
@@ -189,7 +190,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrBtrfsSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }
 
 // Error on fields that are rejected outright by the MCO, or that are
@@ -201,7 +202,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 // so we work in JSON (output) space and then translate paths back to YAML
 // (input) space.  That's also the reason we do these checks after
 // translation, rather than during validation.
-func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateMCOSupport(mc result.MachineConfig) report.Report {
 	// Error classes for the purposes of this function:
 	//
 	// FORBIDDEN - Not supported by the MCD.  If present in MC, MCD will
@@ -281,5 +282,5 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }

--- a/config/openshift/v4_8/translate_test.go
+++ b/config/openshift/v4_8/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/butane/config/common"
 	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_8/result"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -349,7 +350,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -549,7 +551,8 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_8Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/openshift/v4_9/translate.go
+++ b/config/openshift/v4_9/translate.go
@@ -91,8 +91,8 @@ func (c Config) ToMachineConfig4_9Unvalidated(options common.TranslateOptions) (
 	ts.Merge(addLuksFipsOptions(&mc))
 
 	// finally, check the fully desugared config for RHCOS and MCO support
-	r.Merge(validateRHCOSSupport(mc, ts))
-	r.Merge(validateMCOSupport(mc, ts))
+	r.Merge(validateRHCOSSupport(mc))
+	r.Merge(validateMCOSupport(mc))
 
 	return mc, ts, r
 }
@@ -118,7 +118,8 @@ func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Conf
 	// than the Ignition config itself) that we're ignoring
 	mc.Spec.Config = types.Config{}
 	warnings := translate.PrefixReport(cutil.CheckForElidedFields(mc.Spec), "spec")
-	// translate from json space into yaml space
+	// translate from json space into yaml space, since the caller won't
+	// have enough info to do it
 	r.Merge(cutil.TranslateReportPaths(warnings, ts))
 
 	ts = ts.Descend(path.New("json", "spec", "config"))
@@ -181,7 +182,7 @@ OUTER:
 // boot_device.luks), so we work in JSON (output) space and then translate
 // paths back to YAML (input) space.  That's also the reason we do these
 // checks after translation, rather than during validation.
-func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateRHCOSSupport(mc result.MachineConfig) report.Report {
 	var r report.Report
 	for i, fs := range mc.Spec.Config.Storage.Filesystems {
 		if fs.Format != nil && *fs.Format == "btrfs" {
@@ -189,7 +190,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 			r.AddOnError(path.New("json", "spec", "config", "storage", "filesystems", i, "format"), common.ErrBtrfsSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }
 
 // Error on fields that are rejected outright by the MCO, or that are
@@ -201,7 +202,7 @@ func validateRHCOSSupport(mc result.MachineConfig, ts translate.TranslationSet) 
 // so we work in JSON (output) space and then translate paths back to YAML
 // (input) space.  That's also the reason we do these checks after
 // translation, rather than during validation.
-func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) report.Report {
+func validateMCOSupport(mc result.MachineConfig) report.Report {
 	// Error classes for the purposes of this function:
 	//
 	// FORBIDDEN - Not supported by the MCD.  If present in MC, MCD will
@@ -281,5 +282,5 @@ func validateMCOSupport(mc result.MachineConfig, ts translate.TranslationSet) re
 			r.AddOnError(path.New("json", "spec", "config", "passwd", "users", i), common.ErrUserNameSupport)
 		}
 	}
-	return cutil.TranslateReportPaths(r, ts)
+	return r
 }

--- a/config/openshift/v4_9/translate_test.go
+++ b/config/openshift/v4_9/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/butane/config/common"
 	fcos "github.com/coreos/butane/config/fcos/v1_3"
 	"github.com/coreos/butane/config/openshift/v4_9/result"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -349,7 +350,8 @@ func TestTranslateConfig(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("translate %d", i), func(t *testing.T) {
 			actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, test.out, actual, "translation mismatch")
 			assert.Equal(t, report.Report{}, r, "non-empty report")
 			baseutil.VerifyTranslations(t, translations, test.exceptions)
@@ -549,7 +551,8 @@ func TestValidateSupport(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToMachineConfig4_9Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.in, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/r4e/v1_0/translate_test.go
+++ b/config/r4e/v1_0/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_4"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -53,7 +54,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("json", "kernelArguments", "shouldExist", 0),
+					path.New("yaml", "kernel_arguments", "should_exist", 0),
 				},
 			},
 		},
@@ -72,7 +73,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("json", "kernelArguments", "shouldNotExist", 0),
+					path.New("yaml", "kernel_arguments", "should_not_exist", 0),
 				},
 			},
 		},
@@ -93,7 +94,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrDiskSupport,
-					path.New("json", "storage", "disks", 0),
+					path.New("yaml", "storage", "disks", 0),
 				},
 			},
 		},
@@ -115,7 +116,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrFilesystemSupport,
-					path.New("json", "storage", "filesystems", 0),
+					path.New("yaml", "storage", "filesystems", 0),
 				},
 			},
 		},
@@ -136,7 +137,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrLuksSupport,
-					path.New("json", "storage", "luks", 0),
+					path.New("yaml", "storage", "luks", 0),
 				},
 			},
 		},
@@ -157,7 +158,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrRaidSupport,
-					path.New("json", "storage", "raid", 0),
+					path.New("yaml", "storage", "raid", 0),
 				},
 			},
 		},
@@ -169,7 +170,8 @@ func TestTranslateInvalid(t *testing.T) {
 				expectedReport.AddOnError(entry.Path, entry.Err)
 			}
 			actual, translations, r := test.In.ToIgn3_3Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.In, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.In, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/r4e/v1_1/translate_test.go
+++ b/config/r4e/v1_1/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_5"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -53,7 +54,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("json", "kernelArguments", "shouldExist", 0),
+					path.New("yaml", "kernel_arguments", "should_exist", 0),
 				},
 			},
 		},
@@ -72,7 +73,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("json", "kernelArguments", "shouldNotExist", 0),
+					path.New("yaml", "kernel_arguments", "should_not_exist", 0),
 				},
 			},
 		},
@@ -93,7 +94,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrDiskSupport,
-					path.New("json", "storage", "disks", 0),
+					path.New("yaml", "storage", "disks", 0),
 				},
 			},
 		},
@@ -115,7 +116,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrFilesystemSupport,
-					path.New("json", "storage", "filesystems", 0),
+					path.New("yaml", "storage", "filesystems", 0),
 				},
 			},
 		},
@@ -136,7 +137,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrLuksSupport,
-					path.New("json", "storage", "luks", 0),
+					path.New("yaml", "storage", "luks", 0),
 				},
 			},
 		},
@@ -157,7 +158,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrRaidSupport,
-					path.New("json", "storage", "raid", 0),
+					path.New("yaml", "storage", "raid", 0),
 				},
 			},
 		},
@@ -169,7 +170,8 @@ func TestTranslateInvalid(t *testing.T) {
 				expectedReport.AddOnError(entry.Path, entry.Err)
 			}
 			actual, translations, r := test.In.ToIgn3_4Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.In, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.In, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/r4e/v1_2_exp/translate_test.go
+++ b/config/r4e/v1_2_exp/translate_test.go
@@ -21,6 +21,7 @@ import (
 	baseutil "github.com/coreos/butane/base/util"
 	base "github.com/coreos/butane/base/v0_6_exp"
 	"github.com/coreos/butane/config/common"
+	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -53,7 +54,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("json", "kernelArguments", "shouldExist", 0),
+					path.New("yaml", "kernel_arguments", "should_exist", 0),
 				},
 			},
 		},
@@ -72,7 +73,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrGeneralKernelArgumentSupport,
-					path.New("json", "kernelArguments", "shouldNotExist", 0),
+					path.New("yaml", "kernel_arguments", "should_not_exist", 0),
 				},
 			},
 		},
@@ -93,7 +94,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrDiskSupport,
-					path.New("json", "storage", "disks", 0),
+					path.New("yaml", "storage", "disks", 0),
 				},
 			},
 		},
@@ -115,7 +116,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrFilesystemSupport,
-					path.New("json", "storage", "filesystems", 0),
+					path.New("yaml", "storage", "filesystems", 0),
 				},
 			},
 		},
@@ -136,7 +137,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrLuksSupport,
-					path.New("json", "storage", "luks", 0),
+					path.New("yaml", "storage", "luks", 0),
 				},
 			},
 		},
@@ -157,7 +158,7 @@ func TestTranslateInvalid(t *testing.T) {
 				{
 					report.Error,
 					common.ErrRaidSupport,
-					path.New("json", "storage", "raid", 0),
+					path.New("yaml", "storage", "raid", 0),
 				},
 			},
 		},
@@ -169,7 +170,8 @@ func TestTranslateInvalid(t *testing.T) {
 				expectedReport.AddOnError(entry.Path, entry.Err)
 			}
 			actual, translations, r := test.In.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			baseutil.VerifyTranslatedReport(t, test.In, translations, r)
+			r = confutil.TranslateReportPaths(r, translations)
+			baseutil.VerifyReport(t, test.In, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")
 			assert.NoError(t, translations.DebugVerifyCoverage(actual), "incomplete TranslationSet coverage")
 		})

--- a/config/util/util.go
+++ b/config/util/util.go
@@ -62,7 +62,7 @@ func Translate(cfg interface{}, translateMethod string, options common.Translate
 	final := translateRet[0].Interface()
 	translations := translateRet[1].Interface().(translate.TranslationSet)
 	translateReport := translateRet[2].Interface().(report.Report)
-	r.Merge(translateReport)
+	r.Merge(TranslateReportPaths(translateReport, translations))
 	if r.IsFatal() {
 		return zeroValue, r, common.ErrInvalidSourceConfig
 	}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ key](https://getfedora.org/security/).
 
 ### Breaking changes
 
+- Reports from `Unvalidated` functions can now include `json` paths (Go API)
 
 ### Features
 


### PR DESCRIPTION
We were expecting translation functions to return `yaml` paths but weren't ensuring it.  The `r4e` `checkForForbiddenFields()` functions weren't, causing their errors not to identify the correct line and column.

Since #458, `TranslateReportPaths()` automatically ignores paths that are already in `yaml` syntax, so we can just call it once from `config/util.Translate()` and stop requiring each individual translator to call it.

This is a breaking change for any external caller using the `*Unvalidated` functions, since those may now (legally) return a mix of `yaml` and `json` paths.  Probably those functions have no external callers.

While refactoring tests to support this, drop `VerifyTranslatedReport()`.  Tests now translate reports inline and use `VerifyReport()` directly.