### PR TITLE
base: properly snake-case `http_headers` translation

### DIFF
--- a/base/util/test.go
+++ b/base/util/test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -29,9 +30,15 @@ import (
 
 // helper functions for writing tests
 
-// VerifyTranslations ensures all the translations are identity, unless they
-// match a listed one, and verifies that all the listed ones exist.
+// VerifyTranslations validates a TranslationSet from 'yaml' to 'json'.  It
+// expects all translations to be identity, unless they match a listed one,
+// and all the listed ones to exist.
 func VerifyTranslations(t *testing.T, set translate.TranslationSet, exceptions []translate.Translation) {
+	// check tags
+	assert.Equal(t, set.FromTag, "yaml")
+	assert.Equal(t, set.ToTag, "json")
+
+	// build up exceptions and check them
 	exceptionSet := translate.NewTranslationSet(set.FromTag, set.ToTag)
 	for _, ex := range exceptions {
 		exceptionSet.AddTranslation(ex.From, ex.To)
@@ -41,10 +48,17 @@ func VerifyTranslations(t *testing.T, set translate.TranslationSet, exceptions [
 			t.Errorf("missing non-identity translation %v", ex)
 		}
 	}
+
+	// walk translations
 	for key, translation := range set.Set {
+		// unexpected non-identity?
 		if _, ok := exceptionSet.Set[key]; !ok {
 			assert.Equal(t, translation.From.Path, translation.To.Path, "translation is not identity")
 		}
+		// camel case on left?
+		assert.NotRegexp(t, regexp.MustCompile("[A-Z]"), translation.From.String(), "from path in camelCase")
+		// snake case on right?
+		assert.NotContains(t, translation.To.String(), "_", "to path in snake_case")
 	}
 }
 

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -112,7 +112,7 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 func translateResource(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
-	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
+	translate.MergeP2(tr, tm, &r, "http_headers", &from.HTTPHeaders, "httpHeaders", &to.HTTPHeaders)
 	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
 	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -216,8 +216,40 @@ func TestTranslateFile(t *testing.T) {
 			},
 			[]translate.Translation{
 				{
+					From: path.New("yaml", "append", 0, "http_headers"),
+					To:   path.New("json", "append", 0, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0),
+					To:   path.New("json", "append", 0, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "value"),
+				},
+				{
 					From: path.New("yaml", "append", 1, "inline"),
 					To:   path.New("json", "append", 1, "source"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers"),
+					To:   path.New("json", "append", 1, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0),
+					To:   path.New("json", "append", 1, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "value"),
 				},
 				{
 					From: path.New("yaml", "append", 2, "local"),
@@ -226,6 +258,22 @@ func TestTranslateFile(t *testing.T) {
 				{
 					From: path.New("yaml", "append", 2, "local"),
 					To:   path.New("json", "append", 2, "compression"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers"),
+					To:   path.New("json", "contents", "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0),
+					To:   path.New("json", "contents", "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "name"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "value"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "value"),
 				},
 			},
 			"",

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -119,7 +119,7 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 func translateResource(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
-	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
+	translate.MergeP2(tr, tm, &r, "http_headers", &from.HTTPHeaders, "httpHeaders", &to.HTTPHeaders)
 	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
 	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -216,8 +216,40 @@ func TestTranslateFile(t *testing.T) {
 			},
 			[]translate.Translation{
 				{
+					From: path.New("yaml", "append", 0, "http_headers"),
+					To:   path.New("json", "append", 0, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0),
+					To:   path.New("json", "append", 0, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "value"),
+				},
+				{
 					From: path.New("yaml", "append", 1, "inline"),
 					To:   path.New("json", "append", 1, "source"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers"),
+					To:   path.New("json", "append", 1, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0),
+					To:   path.New("json", "append", 1, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "value"),
 				},
 				{
 					From: path.New("yaml", "append", 2, "local"),
@@ -226,6 +258,22 @@ func TestTranslateFile(t *testing.T) {
 				{
 					From: path.New("yaml", "append", 2, "local"),
 					To:   path.New("json", "append", 2, "compression"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers"),
+					To:   path.New("json", "contents", "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0),
+					To:   path.New("json", "contents", "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "name"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "value"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "value"),
 				},
 			},
 			"",

--- a/base/v0_4/translate.go
+++ b/base/v0_4/translate.go
@@ -134,7 +134,7 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 func translateResource(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
-	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
+	translate.MergeP2(tr, tm, &r, "http_headers", &from.HTTPHeaders, "httpHeaders", &to.HTTPHeaders)
 	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
 	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 

--- a/base/v0_4/translate_test.go
+++ b/base/v0_4/translate_test.go
@@ -216,8 +216,40 @@ func TestTranslateFile(t *testing.T) {
 			},
 			[]translate.Translation{
 				{
+					From: path.New("yaml", "append", 0, "http_headers"),
+					To:   path.New("json", "append", 0, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0),
+					To:   path.New("json", "append", 0, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "value"),
+				},
+				{
 					From: path.New("yaml", "append", 1, "inline"),
 					To:   path.New("json", "append", 1, "source"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers"),
+					To:   path.New("json", "append", 1, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0),
+					To:   path.New("json", "append", 1, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "value"),
 				},
 				{
 					From: path.New("yaml", "append", 2, "local"),
@@ -226,6 +258,22 @@ func TestTranslateFile(t *testing.T) {
 				{
 					From: path.New("yaml", "append", 2, "local"),
 					To:   path.New("json", "append", 2, "compression"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers"),
+					To:   path.New("json", "contents", "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0),
+					To:   path.New("json", "contents", "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "name"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "value"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "value"),
 				},
 			},
 			"",

--- a/base/v0_5/translate.go
+++ b/base/v0_5/translate.go
@@ -137,7 +137,7 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 func translateResource(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
-	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
+	translate.MergeP2(tr, tm, &r, "http_headers", &from.HTTPHeaders, "httpHeaders", &to.HTTPHeaders)
 	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
 	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 

--- a/base/v0_5/translate_test.go
+++ b/base/v0_5/translate_test.go
@@ -216,8 +216,40 @@ func TestTranslateFile(t *testing.T) {
 			},
 			[]translate.Translation{
 				{
+					From: path.New("yaml", "append", 0, "http_headers"),
+					To:   path.New("json", "append", 0, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0),
+					To:   path.New("json", "append", 0, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "value"),
+				},
+				{
 					From: path.New("yaml", "append", 1, "inline"),
 					To:   path.New("json", "append", 1, "source"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers"),
+					To:   path.New("json", "append", 1, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0),
+					To:   path.New("json", "append", 1, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "value"),
 				},
 				{
 					From: path.New("yaml", "append", 2, "local"),
@@ -226,6 +258,22 @@ func TestTranslateFile(t *testing.T) {
 				{
 					From: path.New("yaml", "append", 2, "local"),
 					To:   path.New("json", "append", 2, "compression"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers"),
+					To:   path.New("json", "contents", "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0),
+					To:   path.New("json", "contents", "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "name"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "value"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "value"),
 				},
 			},
 			"",

--- a/base/v0_6_exp/translate.go
+++ b/base/v0_6_exp/translate.go
@@ -137,7 +137,7 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 func translateResource(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
-	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
+	translate.MergeP2(tr, tm, &r, "http_headers", &from.HTTPHeaders, "httpHeaders", &to.HTTPHeaders)
 	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
 	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 

--- a/base/v0_6_exp/translate_test.go
+++ b/base/v0_6_exp/translate_test.go
@@ -216,8 +216,40 @@ func TestTranslateFile(t *testing.T) {
 			},
 			[]translate.Translation{
 				{
+					From: path.New("yaml", "append", 0, "http_headers"),
+					To:   path.New("json", "append", 0, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0),
+					To:   path.New("json", "append", 0, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 0, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 0, "httpHeaders", 0, "value"),
+				},
+				{
 					From: path.New("yaml", "append", 1, "inline"),
 					To:   path.New("json", "append", 1, "source"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers"),
+					To:   path.New("json", "append", 1, "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0),
+					To:   path.New("json", "append", 1, "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "name"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "append", 1, "http_headers", 0, "value"),
+					To:   path.New("json", "append", 1, "httpHeaders", 0, "value"),
 				},
 				{
 					From: path.New("yaml", "append", 2, "local"),
@@ -226,6 +258,22 @@ func TestTranslateFile(t *testing.T) {
 				{
 					From: path.New("yaml", "append", 2, "local"),
 					To:   path.New("json", "append", 2, "compression"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers"),
+					To:   path.New("json", "contents", "httpHeaders"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0),
+					To:   path.New("json", "contents", "httpHeaders", 0),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "name"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "name"),
+				},
+				{
+					From: path.New("yaml", "contents", "http_headers", 0, "value"),
+					To:   path.New("json", "contents", "httpHeaders", 0, "value"),
 				},
 			},
 			"",

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,7 @@ key](https://getfedora.org/security/).
 
 ### Bug fixes
 
+- Fix line/column reporting for `http_headers` errors
 - Fix line/column reporting for unsupported field errors _(r4e)_
 
 ### Misc. changes


### PR DESCRIPTION
Fix line/column reporting for `http_headers` errors.