### PR TITLE
fcos: add s390x boot_device sugar

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -54,8 +54,11 @@ var (
 	ErrMountPointForbidden = errors.New("path must be under /etc or /var if with_mount_unit is true")
 
 	// boot device
-	ErrUnknownBootDeviceLayout = errors.New("layout must be one of: aarch64, ppc64le, x86_64")
+	ErrUnknownBootDeviceLayout = errors.New("layout must be one of: aarch64, ppc64le, s390x-eckd, s390x-virt, s390x-zfcp, x86_64")
 	ErrTooFewMirrorDevices     = errors.New("mirroring requires at least two devices")
+	ErrNoLuksBootDevice        = errors.New("device is required for layouts: s390x-eckd, s390x-zfcp")
+	ErrMirrorNotSupport        = errors.New("mirroring not supported on layouts: s390x-eckd, s390x-zfcp, s390x-virt")
+	ErrLuksBootDeviceBadName   = errors.New("device name must start with /dev/dasd on s390x-eckd layout or /dev/sd on s390x-zfcp layout")
 
 	// partition
 	ErrReuseByLabel         = errors.New("partitions cannot be reused by label; number must be specified except on boot disk (/dev/disk/by-id/coreos-boot-disk) or when wipe_table is true")

--- a/config/fcos/v1_6_exp/schema.go
+++ b/config/fcos/v1_6_exp/schema.go
@@ -32,6 +32,7 @@ type BootDevice struct {
 
 type BootDeviceLuks struct {
 	Discard   *bool       `yaml:"discard"`
+	Device    *string     `yaml:"device"`
 	Tang      []base.Tang `yaml:"tang"`
 	Threshold *int        `yaml:"threshold"`
 	Tpm2      *bool       `yaml:"tpm2"`

--- a/docs/config-fcos-v1_6-exp.md
+++ b/docs/config-fcos-v1_6-exp.md
@@ -209,8 +209,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
   * **_should_exist_** (list of strings): the list of kernel arguments that should exist.
   * **_should_not_exist_** (list of strings): the list of kernel arguments that should not exist.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
-  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
+  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, `s390x-eckd`, `s390x-virt`, `s390x-zfcp`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
+    * **_device_** (string): the whole-disk device (not partitions), referenced by their absolute path. Must start with `/dev/dasd` for `s390x-eckd` layout or `/dev/sd` for `s390x-zfcp` layouts.
     * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
       * **url** (string): url of the tang server.
       * **thumbprint** (string): thumbprint of a trusted signing key.

--- a/docs/config-openshift-v4_15-exp.md
+++ b/docs/config-openshift-v4_15-exp.md
@@ -158,8 +158,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
     * **_ssh_authorized_keys_local_** (list of strings): a list of local paths to SSH key files, relative to the directory specified by the `--files-dir` command-line argument, to be added as SSH key fragments at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique. Each file may contain multiple SSH keys, one per line.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
-  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
+  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, `s390x-eckd`, `s390x-virt`, `s390x-zfcp`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
+    * **_device_** (string): the whole-disk device (not partitions), referenced by their absolute path. Must start with `/dev/dasd` for `s390x-eckd` layout or `/dev/sd` for `s390x-zfcp` layouts.
     * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
       * **url** (string): url of the tang server.
       * **thumbprint** (string): thumbprint of a trusted signing key.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -296,6 +296,50 @@ storage:
       format: ext4
 ```
 
+This example uses the shortcut `boot_device` syntax to configure an encrypted root filesystem in s390x on the `dasda` DASD device unlocked with a network Tang server.
+
+<!-- butane-config -->
+```yaml
+variant: fcos
+version: 1.6.0-experimental
+boot_device:
+  layout: s390x-eckd
+  luks:
+    device: /dev/dasda
+    tang:
+      - url: https://tang.example.com
+        thumbprint: REPLACE-THIS-WITH-YOUR-TANG-THUMBPRINT
+```
+
+This example uses the shortcut `boot_device` syntax to configure an encrypted root filesystem in s390x on the `sdb` zFCP device unlocked with a network Tang server.
+
+<!-- butane-config -->
+```yaml
+variant: fcos
+version: 1.6.0-experimental
+boot_device:
+  layout: s390x-zfcp
+  luks:
+    device: /dev/sdb
+    tang:
+      - url: https://tang.example.com
+        thumbprint: REPLACE-THIS-WITH-YOUR-TANG-THUMBPRINT
+```
+
+This example uses the shortcut `boot_device` syntax to configure an encrypted root filesystem in s390x KVM unlocked with a network Tang server.
+
+<!-- butane-config -->
+```yaml
+variant: fcos
+version: 1.6.0-experimental
+boot_device:
+  layout: s390x-virt
+  luks:
+    tang:
+      - url: https://tang.example.com
+        thumbprint: REPLACE-THIS-WITH-YOUR-TANG-THUMBPRINT
+```
+
 ### Mirrored boot disk
 
 This example replicates all default partitions on the boot disk across multiple disks, allowing the system to survive disk failure.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ nav_order: 9
 
 ### Features
 
+- Support s390x layouts in `boot_device` section (fcos 1.6.0-exp, openshift 4.15.0-exp)
 
 ### Bug fixes
 

--- a/internal/doc/butane.yaml
+++ b/internal/doc/butane.yaml
@@ -323,9 +323,19 @@ root:
       children:
         - name: layout
           desc: the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
+          transforms:
+            - regex: "Supported values are (.*), and `x86_64`."
+              replacement: "Supported values are $1, `s390x-eckd`, `s390x-virt`, `s390x-zfcp`, and `x86_64`."
+              if:
+                - variant: fcos
+                  min: 1.6.0-experimental
+                - variant: openshift
+                  min: 4.15.0-experimental 
         - name: luks
           desc: describes the clevis configuration for encrypting the root filesystem.
           children:
+            - name: device
+              desc: the whole-disk device (not partitions), referenced by their absolute path. Must start with `/dev/dasd` for `s390x-eckd` layout or `/dev/sd` for `s390x-zfcp` layouts. 
             - name: tang
               use: tang
             - name: tpm2


### PR DESCRIPTION
Hi,
 
I've closed the earlier pr 483 due to some errors. Here is the new PR.

As per the GitHub issue [https://github.com/coreos/butane/issues/453#issuecomment-1655441505]. The PR contains following conditional changes exclusively for s390x.


1. Added layout specific to s390x .
- > s390x-zfcp  s390x-eckd and s390x-virt .

2.   Added boot_device.luks.device specifically for s390x-zfcp s390x-eckd and forbidden for other arch including s390x-virt.

3.  The configuration will generate only with boot_device.luks and it fails if mirror boot_device.mirror  configuration is specified for s390x-eckd and s390x-zfcp .



