### PR TITLE
Bump minimum Go version to 1.20

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,7 @@ nav_order: 9
 
 ### Misc. changes
 
+- Require Go 1.20+
 
 ### Docs changes
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/butane
 
-go 1.18
+go 1.20
 
 require (
 	github.com/clarketm/json v1.17.1


### PR DESCRIPTION
Go 1.18 is EOL