### PR TITLE
docs/release-notes: update for release

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,26 @@ nav_order: 9
 
 # Release notes
 
-## Upcoming Butane 0.20.0 (unreleased)
+## Upcoming Butane 0.21.0 (unreleased)
+
+
+### Breaking changes
+
+
+### Features
+
+
+### Bug fixes
+
+
+### Misc. changes
+
+
+### Docs changes
+
+
+
+## Butane 0.20.0 (2024-02-19)
 
 Starting with this release, Butane binaries are signed with the [Fedora 39
 key](https://getfedora.org/security/).


### PR DESCRIPTION
Update the release notes for Butane 0.20.0 as per the release checklist issue #512. 
