### PR TITLE
docs: Move s390x boot_devices sugar to ocp 4.16.0-experimental

### DIFF
--- a/docs/config-openshift-v4_15.md
+++ b/docs/config-openshift-v4_15.md
@@ -156,7 +156,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
     * **_ssh_authorized_keys_local_** (list of strings): a list of local paths to SSH key files, relative to the directory specified by the `--files-dir` command-line argument, to be added as SSH key fragments at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique. Each file may contain multiple SSH keys, one per line.
 * **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
-  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, `s390x-eckd`, `s390x-virt`, `s390x-zfcp`, and `x86_64`. Defaults to `x86_64`.
+  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
   * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
     * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
       * **url** (string): url of the tang server.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -33,7 +33,7 @@ key](https://getfedora.org/security/).
 
 ### Features
 
-- Support s390x layouts in `boot_device` section (fcos 1.6.0-exp, openshift 4.15.0-exp)
+- Support s390x layouts in `boot_device` section (fcos 1.6.0-exp, openshift 4.16.0-exp)
 - Stabilize OpenShift spec 4.15.0, targeting Ignition spec 3.4.0
 - Add OpenShift spec 4.16.0-experimental, targeting Ignition spec
   3.5.0-experimental

--- a/internal/doc/butane.yaml
+++ b/internal/doc/butane.yaml
@@ -330,7 +330,7 @@ root:
                 - variant: fcos
                   min: 1.6.0-experimental
                 - variant: openshift
-                  min: 4.15.0-experimental
+                  min: 4.16.0-experimental
         - name: luks
           desc: describes the clevis configuration for encrypting the root filesystem.
           children:


### PR DESCRIPTION
It depends on fcos 1.6.0-experimental

See: https://github.com/coreos/butane/pull/484
See: https://github.com/coreos/butane/pull/514
Fixes: https://github.com/coreos/butane/pull/517