### PR TITLE
flatcar/v1_2_exp: Add clevis support

### DIFF
--- a/config/flatcar/v1_2_exp/translate.go
+++ b/config/flatcar/v1_2_exp/translate.go
@@ -22,15 +22,9 @@ import (
 	"github.com/coreos/vcontext/report"
 )
 
-var (
-	fieldFilters = cutil.NewFilters(types.Config{}, cutil.FilterMap{
-		"storage.luks.clevis": common.ErrClevisSupport,
-	})
-)
-
 // Return FieldFilters for this spec.
 func (c Config) FieldFilters() *cutil.FieldFilters {
-	return &fieldFilters
+	return nil
 }
 
 // ToIgn3_5 translates the config to an Ignition config.  It returns a

--- a/config/flatcar/v1_2_exp/translate_test.go
+++ b/config/flatcar/v1_2_exp/translate_test.go
@@ -59,9 +59,7 @@ func TestTranslation(t *testing.T) {
 					},
 				},
 			},
-			[]entry{
-				{report.Error, common.ErrClevisSupport, path.New("yaml", "storage", "luks", 1, "clevis")},
-			},
+			[]entry{}, // Clevis support was added in 1_2_experimental and we therefore expect no errors.
 		},
 	}
 
@@ -72,7 +70,9 @@ func TestTranslation(t *testing.T) {
 				expectedReport.AddOn(entry.path, entry.err, entry.kind)
 			}
 			actual, translations, r := test.in.ToIgn3_5Unvalidated(common.TranslateOptions{})
-			r.Merge(fieldFilters.Verify(actual))
+			if test.in.FieldFilters() != nil {
+				r.Merge(test.in.FieldFilters().Verify(actual))
+			}
 			r = confutil.TranslateReportPaths(r, translations)
 			baseutil.VerifyReport(t, test.in, r)
 			assert.Equal(t, expectedReport, r, "report mismatch")

--- a/docs/config-flatcar-v1_2-exp.md
+++ b/docs/config-flatcar-v1_2-exp.md
@@ -157,6 +157,17 @@ The Flatcar configuration is a YAML document conforming to the following specifi
     * **_discard_** (boolean): whether to issue discard commands to the underlying block device when blocks are freed. Enabling this improves performance and device longevity on SSDs and space utilization on thinly provisioned SAN devices, but leaks information about which disk blocks contain data. If omitted, it defaults to false.
     * **_open_options_** (list of strings): any additional options to be passed to `cryptsetup luksOpen`. Supported options will be persistently written to the luks volume.
     * **_wipe_volume_** (boolean): whether or not to wipe the device before volume creation, see [Ignition's documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information.
+    * **_clevis_** (object): describes the clevis configuration for the luks device.
+      * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
+        * **url** (string): url of the tang server.
+        * **thumbprint** (string): thumbprint of a trusted signing key.
+        * **_advertisement_** (string): the advertisement JSON. If not specified, the advertisement is fetched from the tang server during provisioning.
+      * **_tpm2_** (boolean): whether or not to use a tpm2 device.
+      * **_threshold_** (integer): sets the minimum number of pieces required to decrypt the device. Default is 1.
+      * **_custom_** (object): overrides the clevis configuration. The `pin` & `config` will be passed directly to `clevis luks bind`. If specified, all other clevis options must be omitted.
+        * **pin** (string): the clevis pin.
+        * **config** (string): the clevis configuration JSON.
+        * **_needs_network_** (boolean): whether or not the device requires networking.
   * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.
     * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
     * **_path_** (string): the path of the tree within the target system. Defaults to `/`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ nav_order: 9
 
 ### Features
 
+- Support `storage.luks.clevis` (flatcar 1.2.0-exp)
 
 ### Bug fixes
 


### PR DESCRIPTION
This PR updates `flatcar/v1_2_exp` to reflect Flatcar can handle disk encryption with clevis, since [this commit](https://github.com/flatcar/scripts/pull/1560).