### PR TITLE
docs/specs: Fix experimental spec mapping

### DIFF
--- a/docs/specs.md
+++ b/docs/specs.md
@@ -73,7 +73,7 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `fcos`         | 1.7.0-experimental  | 3.6.0-experimental |
 | `flatcar`      | 1.0.0               | 3.3.0              |
 | `flatcar`      | 1.1.0               | 3.4.0              |
-| `flatcar`      | 1.2.0-experimental  | 3.5.0-experimental |
+| `flatcar`      | 1.2.0-experimental  | 3.6.0-experimental |
 | `openshift`    | 4.8.0               | 3.2.0              |
 | `openshift`    | 4.9.0               | 3.2.0              |
 | `openshift`    | 4.10.0              | 3.2.0              |
@@ -84,9 +84,9 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `openshift`    | 4.15.0              | 3.4.0              |
 | `openshift`    | 4.16.0              | 3.4.0              |
 | `openshift`    | 4.17.0              | 3.4.0              |
-| `openshift`    | 4.18.0-experimental | 3.5.0-experimental |
+| `openshift`    | 4.18.0-experimental | 3.6.0-experimental |
 | `r4e`          | 1.0.0               | 3.3.0              |
 | `r4e`          | 1.1.0               | 3.4.0              |
-| `r4e`          | 1.2.0-experimental  | 3.5.0-experimental |
+| `r4e`          | 1.2.0-experimental  | 3.6.0-experimental |
 | `fiot`         | 1.0.0               | 3.4.0              |
-| `fiot`         | 1.1.0-experimental  | 3.5.0-experimental |
+| `fiot`         | 1.1.0-experimental  | 3.6.0-experimental |


### PR DESCRIPTION
The experimental specs are now using the 3.6.0-experimental ignition spec.

Fixes: https://github.com/coreos/butane/pull/566