### PR TITLE
docs/specs: Clarify that those are Butane spec versions

### DIFF
--- a/docs/specs.md
+++ b/docs/specs.md
@@ -61,7 +61,7 @@ Do not use **experimental** specifications for anything beyond **development and
 
 Each version of the Butane specification corresponds to a version of the Ignition specification:
 
-| Butane variant | Butane version      | Ignition spec      |
+| Butane variant | Butane spec         | Ignition spec      |
 |----------------|---------------------|--------------------|
 | `fcos`         | 1.0.0               | 3.0.0              |
 | `fcos`         | 1.1.0               | 3.1.0              |


### PR DESCRIPTION
Update the table header listing the correspondance between Butane and Ignition specifications to clarify that we are not speaking about Butane releases / versions here (i.e. the application) but specification versions instead.