### PR TITLE
Dockerfile: use quay.io as source for Fedora base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.fedoraproject.org/fedora:42 AS builder
+FROM quay.io/fedora/fedora:42 AS builder
 RUN dnf install -y golang git-core
 RUN mkdir /butane
 COPY . /butane
 WORKDIR /butane
 RUN ./build_for_container
 
-FROM registry.fedoraproject.org/fedora-minimal:42
+FROM quay.io/fedora/fedora-minimal:42
 COPY --from=builder /butane/bin/container/butane /usr/local/bin/butane
 ENTRYPOINT ["/usr/local/bin/butane"]


### PR DESCRIPTION
Switch the builder stage from `registry.fedoraproject.org` to `quay.io/fedora/fedora:42` to align with common usage in container build workflows.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1851