### PR TITLE
Add github workflow for butane gating test

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -1,0 +1,75 @@
+name: TMT Tests
+
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      plan_filter:
+        description: |
+          Test plan filter name, ie: tag:smoke.
+          If provided, only tests matching this filter will be run, otherwise all tests will be run.
+          From the TMT help:
+            Apply an advanced filter using key:value
+            pairs and logical operators. For example
+            'tier:1 & tag:core'. Use the 'name' key to
+            search by name. See 'pydoc fmf.filter' for
+            detailed documentation on the syntax
+        required: false
+        default: ''
+      use_built_from_src:
+        description: 'Built butane from source instead of install distro package'
+        required: false
+        default: 'true'
+
+jobs:
+  tmt-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Set additional paths
+        run: |
+          set -x -e -o pipefail
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          set -x -e -o pipefail
+          sudo apt-get update
+          sudo apt-get install -y podman libblkid-dev rsync
+          pip install --user tmt
+      - name: Build butane
+        if: github.event.inputs.use_built_from_src == '' || github.event.inputs.use_built_from_src == 'true'
+        run: |
+          set -x -e -o pipefail
+          ./build_for_container
+      - name: Run TMT tests
+        run: |
+          set -x -e -o pipefail
+          if [ "$ACT" = "true" ]; then
+            echo "Running locally using ACT" # ACT ref:  https://github.com/nektos/act
+            TMT_PROVISION_OPTS="--how local --feeling-safe"
+          else
+            TMT_PROVISION_OPTS="--how container"
+          fi
+          if [ -n "${{ github.event.inputs.plan_filter }}" ]; then
+            PLAN_FILTER_PARAM="plan --filter '${{ github.event.inputs.plan_filter }}'"
+          fi
+          if [ -z "${{ github.event.inputs.use_built_from_src }}" ] || [ "${{ github.event.inputs.use_built_from_src }}" == "true" ]; then
+            CONTEXT_PARAM="--context use_built_from_src=true"
+          else
+            CONTEXT_PARAM="--context use_built_from_src=false"
+          fi
+          # eval is used to allow the use of variables in the command
+          # and to avoid issues withe the tmt --filter option
+          eval "tmt $CONTEXT_PARAM run --all --debug -vvvv provision $TMT_PROVISION_OPTS $PLAN_FILTER_PARAM"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,6 +23,7 @@ nav_order: 9
 - Stabilize OpenShift spec 4.19.0, targeting Ignition spec 3.5.0
 - Add OpenShift spec 4.20.0-experimental, targeting Ignition spec
   3.6.0-experimental
+- Add TMT test support with initial smoke test
 
 ### Bug fixes
 

--- a/tests/core/core.fmf
+++ b/tests/core/core.fmf
@@ -1,0 +1,7 @@
+summary: runs butane --version and checks return code
+tag:
+  - smoke
+test: |
+  set -x -e -o pipefail
+  source /tmp/butane_bin_dir
+  ${BUTANE_BIN_DIR}/butane --version

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -1,2 +1,0 @@
-require:
-  - butane

--- a/tests/smoke/main.fmf
+++ b/tests/smoke/main.fmf
@@ -1,4 +1,0 @@
-summary: runs butane --version and checks return code 
-test: ./test.sh
-tag:
-- smoke

--- a/tests/smoke/test.sh
+++ b/tests/smoke/test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-butane --version

--- a/tests/tmt/plans/main.fmf
+++ b/tests/tmt/plans/main.fmf
@@ -1,0 +1,32 @@
+# This prepare is used to control when butane is installed using
+# the distribution package or when it is built from source in the test environment
+prepare:
+  - name: Set BUTANE_BIN_DIR when built from source
+    when: use_built_from_src is defined and use_built_from_src == true
+    how: shell
+    script: |
+      # This is a workaround script for the fact that the butane binary is not in the PATH
+      # when running the tests in the tmt environment when it is built from source.
+      # The butane binary is located in the tmt run instance directory and it needed
+      # to set a environment variable to point to the butane binary location.
+      set -x -e -o pipefail
+      echo "Preparing the test environment"
+      BUTANE_BIN_NAME="butane"
+      PARENT_DIR=$(dirname "${TMT_TREE}")
+      BUTANE_BIN_FULL_PATH=$(find "${PARENT_DIR}" -type f -name "${BUTANE_BIN_NAME}")
+      if [ -z "${BUTANE_BIN_FULL_PATH}" ]; then
+          echo "butane file not found."
+          exit 1
+      fi
+      BUTANE_BIN_DIR=$(dirname "${BUTANE_BIN_FULL_PATH}")
+      echo "BUTANE_BIN_DIR=${BUTANE_BIN_DIR}" > /tmp/butane_bin_dir
+  - name: Install butane package
+    when: use_built_from_src is not defined or use_built_from_src == false
+    how: install
+    package: butane
+  - name: Set BUTANE_BIN_DIR when installed package
+    when: use_built_from_src is not defined or use_built_from_src == false
+    how: shell
+    script: |
+      set -x -e -o pipefail
+      echo "BUTANE_BIN_DIR=/usr/bin/butane"  > /tmp/butane_bin_dir

--- a/tests/tmt/plans/smoke.fmf
+++ b/tests/tmt/plans/smoke.fmf
@@ -1,6 +1,9 @@
 summary: Basic smoke test
+tag:
+  - smoke
 discover:
   how: fmf
   filter: "tag: smoke"
 execute:
   how: tmt
+


### PR DESCRIPTION
This workflow executes TMT gating tests for all pull requests to ensure Butane configurations remain valid and prevent regressions.