### PR TITLE
STOR-2358: Use XTS encryption in FIPS mode

### DIFF
--- a/config/openshift/v4_18/translate.go
+++ b/config/openshift/v4_18/translate.go
@@ -53,10 +53,9 @@ import (
 // these.
 
 const (
-	// FIPS 140-2 doesn't allow the default XTS mode
 	fipsCipherOption      = types.LuksOption("--cipher")
 	fipsCipherShortOption = types.LuksOption("-c")
-	fipsCipherArgument    = types.LuksOption("aes-cbc-essiv:sha256")
+	fipsCipherArgument    = types.LuksOption("aes-xts-plain64")
 )
 
 var (

--- a/config/openshift/v4_19/translate.go
+++ b/config/openshift/v4_19/translate.go
@@ -53,10 +53,9 @@ import (
 // these.
 
 const (
-	// FIPS 140-2 doesn't allow the default XTS mode
 	fipsCipherOption      = types.LuksOption("--cipher")
 	fipsCipherShortOption = types.LuksOption("-c")
-	fipsCipherArgument    = types.LuksOption("aes-cbc-essiv:sha256")
+	fipsCipherArgument    = types.LuksOption("aes-xts-plain64")
 )
 
 var (

--- a/config/openshift/v4_20_exp/translate.go
+++ b/config/openshift/v4_20_exp/translate.go
@@ -53,10 +53,9 @@ import (
 // these.
 
 const (
-	// FIPS 140-2 doesn't allow the default XTS mode
 	fipsCipherOption      = types.LuksOption("--cipher")
 	fipsCipherShortOption = types.LuksOption("-c")
-	fipsCipherArgument    = types.LuksOption("aes-cbc-essiv:sha256")
+	fipsCipherArgument    = types.LuksOption("aes-xts-plain64")
 )
 
 var (


### PR DESCRIPTION
Earlier versions of OpenShift defaulted to aes encryption due to incompatibility with FIPS 140-2. It has been confirmed that XTS is compatible with 140-2. As it is a preferred algorithm, we should default to it.

This default should be carried over in perpetuity. Hopefully this code accomplishes that.

Reference:
https://csrc.nist.gov/csrc/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp2273.pdf