### PR TITLE
bugfix: add validation for bootdevice mirror

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -57,6 +57,7 @@ var (
 	ErrUnknownBootDeviceLayout       = errors.New("layout must be one of: aarch64, ppc64le, s390x-eckd, s390x-virt, s390x-zfcp, x86_64")
 	ErrUnknownBootDeviceLayoutLegacy = errors.New("layout must be one of: aarch64, ppc64le, x86_64")
 	ErrTooFewMirrorDevices           = errors.New("mirroring requires at least two devices")
+	ErrMirrorRequiresLayout          = errors.New("boot_device.layout should be specified when boot_device.mirror is specified")
 	ErrNoLuksBootDevice              = errors.New("device is required for layouts: s390x-eckd, s390x-zfcp")
 	ErrMirrorNotSupport              = errors.New("mirroring not supported on layouts: s390x-eckd, s390x-zfcp, s390x-virt")
 	ErrLuksBootDeviceBadName         = errors.New("device name must start with /dev/dasd on s390x-eckd layout or /dev/sd on s390x-zfcp layout")

--- a/config/fcos/v1_3/validate.go
+++ b/config/fcos/v1_3/validate.go
@@ -22,6 +22,10 @@ import (
 )
 
 func (d BootDevice) Validate(c path.ContextPath) (r report.Report) {
+	if len(d.Mirror.Devices) > 0 && d.Layout == nil {
+		r.AddOnWarn(c.Append("mirror"), common.ErrMirrorRequiresLayout)
+	}
+
 	if d.Layout != nil {
 		switch *d.Layout {
 		case "aarch64", "ppc64le", "x86_64":

--- a/config/fcos/v1_3/validate_test.go
+++ b/config/fcos/v1_3/validate_test.go
@@ -170,6 +170,7 @@ func TestValidateBootDevice(t *testing.T) {
 		// only one mirror device
 		{
 			BootDevice{
+				Layout: util.StrToPtr("x86_64"),
 				Mirror: BootDeviceMirror{
 					Devices: []string{"/dev/vda"},
 				},

--- a/config/fcos/v1_4/validate.go
+++ b/config/fcos/v1_4/validate.go
@@ -22,6 +22,10 @@ import (
 )
 
 func (d BootDevice) Validate(c path.ContextPath) (r report.Report) {
+	if len(d.Mirror.Devices) > 0 && d.Layout == nil {
+		r.AddOnWarn(c.Append("mirror"), common.ErrMirrorRequiresLayout)
+	}
+
 	if d.Layout != nil {
 		switch *d.Layout {
 		case "aarch64", "ppc64le", "x86_64":

--- a/config/fcos/v1_4/validate_test.go
+++ b/config/fcos/v1_4/validate_test.go
@@ -170,6 +170,7 @@ func TestValidateBootDevice(t *testing.T) {
 		// only one mirror device
 		{
 			BootDevice{
+				Layout: util.StrToPtr("x86_64"),
 				Mirror: BootDeviceMirror{
 					Devices: []string{"/dev/vda"},
 				},

--- a/config/fcos/v1_5/validate.go
+++ b/config/fcos/v1_5/validate.go
@@ -23,6 +23,10 @@ import (
 )
 
 func (d BootDevice) Validate(c path.ContextPath) (r report.Report) {
+	if len(d.Mirror.Devices) > 0 && d.Layout == nil {
+		r.AddOnWarn(c.Append("mirror"), common.ErrMirrorRequiresLayout)
+	}
+
 	if d.Layout != nil {
 		switch *d.Layout {
 		case "aarch64", "ppc64le", "x86_64":

--- a/config/fcos/v1_5/validate_test.go
+++ b/config/fcos/v1_5/validate_test.go
@@ -170,6 +170,7 @@ func TestValidateBootDevice(t *testing.T) {
 		// only one mirror device
 		{
 			BootDevice{
+				Layout: util.StrToPtr("x86_64"),
 				Mirror: BootDeviceMirror{
 					Devices: []string{"/dev/vda"},
 				},

--- a/config/fcos/v1_6/validate.go
+++ b/config/fcos/v1_6/validate.go
@@ -53,6 +53,10 @@ func (conf Config) Validate(c path.ContextPath) (r report.Report) {
 }
 
 func (d BootDevice) Validate(c path.ContextPath) (r report.Report) {
+	if len(d.Mirror.Devices) > 0 && d.Layout == nil {
+		r.AddOnWarn(c.Append("mirror"), common.ErrMirrorRequiresLayout)
+	}
+
 	if d.Layout != nil {
 		switch *d.Layout {
 		case "aarch64", "ppc64le", "x86_64":

--- a/config/fcos/v1_7_exp/validate.go
+++ b/config/fcos/v1_7_exp/validate.go
@@ -54,6 +54,10 @@ func (conf Config) Validate(c path.ContextPath) (r report.Report) {
 }
 
 func (d BootDevice) Validate(c path.ContextPath) (r report.Report) {
+	if len(d.Mirror.Devices) > 0 && d.Layout == nil {
+		r.AddOnError(c.Append("mirror"), common.ErrMirrorRequiresLayout)
+	}
+
 	if d.Layout != nil {
 		switch *d.Layout {
 		case "aarch64", "ppc64le", "x86_64":

--- a/config/fcos/v1_7_exp/validate_test.go
+++ b/config/fcos/v1_7_exp/validate_test.go
@@ -246,6 +246,7 @@ func TestValidateBootDevice(t *testing.T) {
 		// only one mirror device
 		{
 			BootDevice{
+				Layout: util.StrToPtr("x86_64"),
 				Mirror: BootDeviceMirror{
 					Devices: []string{"/dev/vda"},
 				},
@@ -302,6 +303,27 @@ func TestValidateBootDevice(t *testing.T) {
 			},
 			common.ErrLuksBootDeviceBadName,
 			path.New("yaml", "layout"),
+		},
+		// mirror with layout should succeed
+		{
+			BootDevice{
+				Layout: util.StrToPtr("aarch64"),
+				Mirror: BootDeviceMirror{
+					Devices: []string{"/dev/vda", "/dev/vdb"},
+				},
+			},
+			nil,
+			path.New("yaml"),
+		},
+		// mirror without layout
+		{
+			BootDevice{
+				Mirror: BootDeviceMirror{
+					Devices: []string{"/dev/vda", "/dev/vdb"},
+				},
+			},
+			common.ErrMirrorRequiresLayout,
+			path.New("yaml", "mirror"),
 		},
 	}
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -363,6 +363,7 @@ This example replicates all default partitions on the boot disk across multiple 
 variant: fcos
 version: 1.3.0
 boot_device:
+  layout: x86_64
   mirror:
     devices:
       - /dev/sda
@@ -376,6 +377,7 @@ This example configures a mirrored boot disk with a TPM2-encrypted root filesyst
 variant: fcos
 version: 1.3.0
 boot_device:
+  layout: x86_64
   luks:
     tpm2: true
   mirror:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,13 +6,21 @@ nav_order: 9
 
 ## Upcoming Butane 0.26.0 (unreleased)
 
+### Breaking changes
+
+- Require `boot_device.layout` when using `boot_device.mirror` _(fcos 1.7.0-exp)_
+
 ### Features
 
 ### Bug fixes
 
+- Warn for `boot_device.layout` to be specified when using `boot_device.mirror` _(fcos 1.3.0-1.6.0)_
+
 ### Misc. changes
 
 ### Docs changes
+
+- Update `boot_device.mirror` examples to specify `boot_device.layout`
 
 ## Butane 0.25.1 (2025-09-24)
 


### PR DESCRIPTION
It comes down to we should have made it a requirement when using device.mirror.
To not break existing configs lets add a warning from start, that way people will be notified but not interrupted. 


fixes: https://github.com/coreos/butane/issues/592