### PR TITLE
Add cli option to output all strings in plain text

### DIFF
--- a/base/util/url.go
+++ b/base/util/url.go
@@ -24,7 +24,13 @@ import (
 	"github.com/vincent-petithory/dataurl"
 )
 
-func MakeDataURL(contents []byte, currentCompression *string, allowCompression bool) (uri string, compression *string, err error) {
+func MakeDataURL(contents []byte, currentCompression *string, allowCompression bool, humanReadableEncoding bool) (uri string, compression *string, err error) {
+	if humanReadableEncoding {
+		compression = util.StrToPtr("")
+		uri = string(contents)
+		return
+	}
+
 	// try three different encodings, and select the smallest one
 
 	if util.NilOrEmpty(currentCompression) {

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -132,7 +132,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 				return
 			}
 		}
-		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -148,7 +148,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -270,7 +270,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
+			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression, false)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -139,7 +139,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 				return
 			}
 		}
-		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -155,7 +155,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -277,7 +277,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
+			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression, false)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_4/translate.go
+++ b/base/v0_4/translate.go
@@ -154,7 +154,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 				return
 			}
 		}
-		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -170,7 +170,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -292,7 +292,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
+			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression, false)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_5/translate.go
+++ b/base/v0_5/translate.go
@@ -157,7 +157,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 				return
 			}
 		}
-		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -173,7 +173,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -382,7 +382,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
+			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression, false)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_6/translate.go
+++ b/base/v0_6/translate.go
@@ -157,7 +157,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 				return
 			}
 		}
-		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -173,7 +173,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression, false)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -382,7 +382,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
+			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression, false)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_7_exp/translate.go
+++ b/base/v0_7_exp/translate.go
@@ -158,7 +158,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			}
 		}
 
-		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression, options.PlainTextEncoding)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -174,7 +174,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
+		src, compression, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression, options.PlainTextEncoding)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -421,7 +421,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
+			url, compression, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression, options.PlainTextEncoding)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -15,9 +15,10 @@
 package common
 
 type TranslateOptions struct {
-	FilesDir                  string // allow embedding local files relative to this directory
-	NoResourceAutoCompression bool   // skip automatic compression of inline/local resources
-	DebugPrintTranslations    bool   // report translations to stderr
+	FilesDir                  	string 	// allow embedding local files relative to this directory
+	NoResourceAutoCompression 	bool   	// skip automatic compression of inline/local resources
+	PlainTextEncoding     		bool   	// plain text, only for debugging
+	DebugPrintTranslations    	bool   	// report translations to stderr
 }
 
 type TranslateBytesOptions struct {

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -15,10 +15,10 @@
 package common
 
 type TranslateOptions struct {
-	FilesDir                  	string 	// allow embedding local files relative to this directory
-	NoResourceAutoCompression 	bool   	// skip automatic compression of inline/local resources
-	PlainTextEncoding     		bool   	// plain text, only for debugging
-	DebugPrintTranslations    	bool   	// report translations to stderr
+	FilesDir                  string // allow embedding local files relative to this directory
+	NoResourceAutoCompression bool   // skip automatic compression of inline/local resources
+	PlainTextEncoding         bool   // plain text, only for debugging
+	DebugPrintTranslations    bool   // report translations to stderr
 }
 
 type TranslateBytesOptions struct {

--- a/config/fcos/v1_5/translate.go
+++ b/config/fcos/v1_5/translate.go
@@ -327,7 +327,7 @@ func (c Config) handleUserGrubCfg(options common.TranslateOptions) (types.Config
 		})
 
 	userCfgContent := []byte(buildGrubConfig(c.Grub))
-	src, compression, err := baseutil.MakeDataURL(userCfgContent, nil, !options.NoResourceAutoCompression)
+	src, compression, err := baseutil.MakeDataURL(userCfgContent, nil, !options.NoResourceAutoCompression, false)
 	if err != nil {
 		r.AddOnError(yamlPath, err)
 		return rendered, ts, r

--- a/config/fcos/v1_6/translate.go
+++ b/config/fcos/v1_6/translate.go
@@ -371,7 +371,7 @@ func (c Config) handleUserGrubCfg(options common.TranslateOptions) (types.Config
 		})
 
 	userCfgContent := []byte(buildGrubConfig(c.Grub))
-	src, compression, err := baseutil.MakeDataURL(userCfgContent, nil, !options.NoResourceAutoCompression)
+	src, compression, err := baseutil.MakeDataURL(userCfgContent, nil, !options.NoResourceAutoCompression, false)
 	if err != nil {
 		r.AddOnError(yamlPath, err)
 		return rendered, ts, r

--- a/config/fcos/v1_7_exp/translate.go
+++ b/config/fcos/v1_7_exp/translate.go
@@ -371,7 +371,7 @@ func (c Config) handleUserGrubCfg(options common.TranslateOptions) (types.Config
 		})
 
 	userCfgContent := []byte(buildGrubConfig(c.Grub))
-	src, compression, err := baseutil.MakeDataURL(userCfgContent, nil, !options.NoResourceAutoCompression)
+	src, compression, err := baseutil.MakeDataURL(userCfgContent, nil, !options.NoResourceAutoCompression, false)
 	if err != nil {
 		r.AddOnError(yamlPath, err)
 		return rendered, ts, r

--- a/config/util/util.go
+++ b/config/util/util.go
@@ -92,9 +92,12 @@ func Translate(cfg Config, translateMethod string, options common.TranslateOptio
 	dupsReport := validate.ValidateCustom(final, "json", ignvalidate.ValidateDups)
 	r.Merge(TranslateReportPaths(dupsReport, translations))
 
-	// Validate JSON semantics.
-	jsonReport := validate.Validate(final, "json")
-	r.Merge(TranslateReportPaths(jsonReport, translations))
+	// When user use --plain-text flag, we skip the JSON semantics validation because the resulting Ignition is invalid, and this is for debug only
+	if !options.PlainTextEncoding {
+		// Validate JSON semantics.
+		jsonReport := validate.Validate(final, "json")
+		r.Merge(TranslateReportPaths(jsonReport, translations))
+	}
 
 	if r.IsFatal() {
 		return zeroValue, r, common.ErrInvalidGeneratedConfig

--- a/internal/main.go
+++ b/internal/main.go
@@ -54,6 +54,8 @@ func main() {
 	pflag.Lookup("input").Hidden = true
 	pflag.StringVarP(&output, "output", "o", "", "write to output file instead of stdout")
 	pflag.StringVarP(&options.FilesDir, "files-dir", "d", "", "allow embedding local files from this directory")
+	pflag.BoolVar(&options.PlainTextEncoding, "plain-text", false,
+		"use plain text only -- only for debugging, should not be used for configs!!!")
 
 	pflag.Usage = func() {
 		fmt.Fprintf(pflag.CommandLine.Output(), "Usage: %s [options] [input-file]\n", os.Args[0])


### PR DESCRIPTION
Adding --plain-text CLI flag to generate an Ignition config in plain text This generated config should be used for debugging only

Fixes: #670