### PR TITLE
docs/release-notes: note Fedora 44 signing key

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,9 @@ nav_order: 9
 
 ## Butane 0.28.0 (2026-05-19)
 
+Starting with this release, Butane binaries are signed with the [Fedora 44
+key](https://getfedora.org/security/).
+
 ### Features
 
 - Stabilize OpenShift spec 4.22.0, targeting Ignition spec 3.6.0


### PR DESCRIPTION
Add release notes entry for PR #707, noting that starting with 0.28.0, Butane binaries are signed with the Fedora 44 key