### PR TITLE
fcos: skip ErrReuseByLabel warning for boot_device.mirror disks

### DIFF
--- a/config/fcos/v1_6/validate.go
+++ b/config/fcos/v1_6/validate.go
@@ -35,8 +35,14 @@ var sdRe = regexp.MustCompile("(/dev/sd[a-z]$)")
 // We can't define a Validate function directly on Disk because that's defined in base,
 // so we use a Validate function on the top-level Config instead.
 func (conf Config) Validate(c path.ContextPath) (r report.Report) {
+	// Collect mirror device paths so we can skip the reuse-by-label
+	// check for them; processBootDevice() will set wipe_table: true.
+	mirrorDevices := make(map[string]bool)
+	for _, dev := range conf.BootDevice.Mirror.Devices {
+		mirrorDevices[dev] = true
+	}
 	for i, disk := range conf.Storage.Disks {
-		if disk.Device != rootDevice && !util.IsTrue(disk.WipeTable) {
+		if disk.Device != rootDevice && !util.IsTrue(disk.WipeTable) && !mirrorDevices[disk.Device] {
 			for p, partition := range disk.Partitions {
 				if partition.Number == 0 && partition.Label != nil {
 					r.AddOnWarn(c.Append("storage", "disks", i, "partitions", p, "number"), common.ErrReuseByLabel)

--- a/config/fcos/v1_6/validate_test.go
+++ b/config/fcos/v1_6/validate_test.go
@@ -583,6 +583,30 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 		},
+		// valid config (disk is a boot_device.mirror device)
+		{
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/sda",
+								Partitions: []base.Partition{
+									{
+										Label: util.StrToPtr("root-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+				BootDevice: BootDevice{
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/sda", "/dev/sdb"},
+					},
+				},
+			},
+		},
 		// invalid config (wipe_table is nil)
 		{
 			in: Config{

--- a/config/fcos/v1_7/validate.go
+++ b/config/fcos/v1_7/validate.go
@@ -36,8 +36,14 @@ var sdRe = regexp.MustCompile("(/dev/sd[a-z]$)")
 // We can't define a Validate function directly on Disk because that's defined in base,
 // so we use a Validate function on the top-level Config instead.
 func (conf Config) Validate(c path.ContextPath) (r report.Report) {
+	// Collect mirror device paths so we can skip the reuse-by-label
+	// check for them; processBootDevice() will set wipe_table: true.
+	mirrorDevices := make(map[string]bool)
+	for _, dev := range conf.BootDevice.Mirror.Devices {
+		mirrorDevices[dev] = true
+	}
 	for i, disk := range conf.Storage.Disks {
-		if disk.Device != rootDevice && !util.IsTrue(disk.WipeTable) {
+		if disk.Device != rootDevice && !util.IsTrue(disk.WipeTable) && !mirrorDevices[disk.Device] {
 			for p, partition := range disk.Partitions {
 				if partition.Number == 0 && partition.Label != nil {
 					r.AddOnWarn(c.Append("storage", "disks", i, "partitions", p, "number"), common.ErrReuseByLabel)

--- a/config/fcos/v1_7/validate_test.go
+++ b/config/fcos/v1_7/validate_test.go
@@ -566,6 +566,30 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 		},
+		// valid config (disk is a boot_device.mirror device)
+		{
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/sda",
+								Partitions: []base.Partition{
+									{
+										Label: util.StrToPtr("root-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+				BootDevice: BootDevice{
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/sda", "/dev/sdb"},
+					},
+				},
+			},
+		},
 		// invalid config (wipe_table is nil)
 		{
 			in: Config{

--- a/config/fcos/v1_8_exp/validate.go
+++ b/config/fcos/v1_8_exp/validate.go
@@ -36,8 +36,14 @@ var sdRe = regexp.MustCompile("(/dev/sd[a-z]$)")
 // We can't define a Validate function directly on Disk because that's defined in base,
 // so we use a Validate function on the top-level Config instead.
 func (conf Config) Validate(c path.ContextPath) (r report.Report) {
+	// Collect mirror device paths so we can skip the reuse-by-label
+	// check for them; processBootDevice() will set wipe_table: true.
+	mirrorDevices := make(map[string]bool)
+	for _, dev := range conf.BootDevice.Mirror.Devices {
+		mirrorDevices[dev] = true
+	}
 	for i, disk := range conf.Storage.Disks {
-		if disk.Device != rootDevice && !util.IsTrue(disk.WipeTable) {
+		if disk.Device != rootDevice && !util.IsTrue(disk.WipeTable) && !mirrorDevices[disk.Device] {
 			for p, partition := range disk.Partitions {
 				if partition.Number == 0 && partition.Label != nil {
 					r.AddOnWarn(c.Append("storage", "disks", i, "partitions", p, "number"), common.ErrReuseByLabel)

--- a/config/fcos/v1_8_exp/validate_test.go
+++ b/config/fcos/v1_8_exp/validate_test.go
@@ -566,6 +566,30 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 		},
+		// valid config (disk is a boot_device.mirror device)
+		{
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/sda",
+								Partitions: []base.Partition{
+									{
+										Label: util.StrToPtr("root-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+				BootDevice: BootDevice{
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/sda", "/dev/sdb"},
+					},
+				},
+			},
+		},
 		// invalid config (wipe_table is nil)
 		{
 			in: Config{

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,10 @@ key](https://getfedora.org/security/).
   _(fcos 1.8.0-exp, fiot 1.1.0-exp, flatcar 1.2.0-exp, openshift
   4.23.0-exp, r4e 1.2.0-exp)_
 
+### Bug fixes
+
+- Don't warn about partitions being reused by label for boot_device.mirror disks
+
 ### Misc. changes
 
 - Warn on root partition size is too small _(fcos 1.3.0-1.8.0-exp)_


### PR DESCRIPTION
Config.Validate() warns when a partition on a non-boot disk uses a label without an explicit number and wipe_table is not set.  However, when the disk is listed in boot_device.mirror.devices, this warning is a false positive: processBootDevice() in translate.go will auto- generate wipe_table: true for mirror disks, but Validate() runs before translation so it doesn't see the auto-generated wipe_table.

The user can't reasonably suppress this: adding explicit wipe_table: true is redundant, and adding explicit partition number fields would break the label-based merge with the auto-generated mirror partitions.

Skip the ErrReuseByLabel check for disks that are listed in boot_device.mirror.devices.

Fixes: https://github.com/coreos/butane/issues/710

Assisted-by: <anthropic/claude-opus-4.6>