### PR TITLE
OCP 4.22 MCO does not support Ignition spec 3.6.0 produced by Butane openshift 4.22.0

### DIFF
--- a/config/openshift/v4_22/result/schema.go
+++ b/config/openshift/v4_22/result/schema.go
@@ -15,7 +15,7 @@
 package result
 
 import (
-	"github.com/coreos/ignition/v2/config/v3_6/types"
+	"github.com/coreos/ignition/v2/config/v3_5/types"
 )
 
 const (

--- a/config/openshift/v4_22/schema.go
+++ b/config/openshift/v4_22/schema.go
@@ -15,7 +15,7 @@
 package v4_22
 
 import (
-	fcos "github.com/coreos/butane/config/fcos/v1_7"
+	fcos "github.com/coreos/butane/config/fcos/v1_6"
 )
 
 const ROLE_LABEL_KEY = "machineconfiguration.openshift.io/role"

--- a/config/openshift/v4_22/translate.go
+++ b/config/openshift/v4_22/translate.go
@@ -22,7 +22,7 @@ import (
 	cutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
-	"github.com/coreos/ignition/v2/config/v3_6/types"
+	"github.com/coreos/ignition/v2/config/v3_5/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
@@ -104,7 +104,7 @@ func (c Config) FieldFilters() *cutil.FieldFilters {
 // can be tracked back to their source in the source config.  No config
 // validation is performed on input or output.
 func (c Config) ToMachineConfig4_22Unvalidated(options common.TranslateOptions) (result.MachineConfig, translate.TranslationSet, report.Report) {
-	cfg, ts, r := c.Config.ToIgn3_6Unvalidated(options)
+	cfg, ts, r := c.Config.ToIgn3_5Unvalidated(options)
 	if r.IsFatal() {
 		return result.MachineConfig{}, ts, r
 	}
@@ -161,11 +161,11 @@ func (c Config) ToMachineConfig4_22(options common.TranslateOptions) (result.Mac
 	return cfg.(result.MachineConfig), r, err
 }
 
-// ToIgn3_6Unvalidated translates the config to an Ignition config.  It also
+// ToIgn3_5Unvalidated translates the config to an Ignition config.  It also
 // returns the set of translations it did so paths in the resultant config
 // can be tracked back to their source in the source config.  No config
 // validation is performed on input or output.
-func (c Config) ToIgn3_6Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+func (c Config) ToIgn3_5Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
 	mc, ts, r := c.ToMachineConfig4_22Unvalidated(options)
 	cfg := mc.Spec.Config
 
@@ -181,21 +181,21 @@ func (c Config) ToIgn3_6Unvalidated(options common.TranslateOptions) (types.Conf
 	return cfg, ts, r
 }
 
-// ToIgn3_6 translates the config to an Ignition config.  It returns a
+// ToIgn3_5 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If
 // the report has fatal errors or it encounters other problems translating,
 // an error is returned.
-func (c Config) ToIgn3_6(options common.TranslateOptions) (types.Config, report.Report, error) {
-	cfg, r, err := cutil.Translate(c, "ToIgn3_6Unvalidated", options)
+func (c Config) ToIgn3_5(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_5Unvalidated", options)
 	return cfg.(types.Config), r, err
 }
 
-// ToConfigBytes translates from a v4.22 Butane config to a v4.22 MachineConfig or a v3.6.0 Ignition config. It returns a report of any errors or
+// ToConfigBytes translates from a v4.22 Butane config to a v4.22 MachineConfig or a v3.5.0 Ignition config. It returns a report of any errors or
 // warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
 // translating, an error is returned.
 func ToConfigBytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
 	if options.Raw {
-		return cutil.TranslateBytes(input, &Config{}, "ToIgn3_6", options)
+		return cutil.TranslateBytes(input, &Config{}, "ToIgn3_5", options)
 	} else {
 		return cutil.TranslateBytesYAML(input, &Config{}, "ToMachineConfig4_22", options)
 	}

--- a/config/openshift/v4_22/translate_test.go
+++ b/config/openshift/v4_22/translate_test.go
@@ -19,15 +19,15 @@ import (
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
-	base "github.com/coreos/butane/base/v0_7"
+	base "github.com/coreos/butane/base/v0_6"
 	"github.com/coreos/butane/config/common"
-	fcos "github.com/coreos/butane/config/fcos/v1_7"
+	fcos "github.com/coreos/butane/config/fcos/v1_6"
 	"github.com/coreos/butane/config/openshift/v4_22/result"
 	confutil "github.com/coreos/butane/config/util"
 	"github.com/coreos/butane/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/ignition/v2/config/v3_6/types"
+	"github.com/coreos/ignition/v2/config/v3_5/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
@@ -52,7 +52,7 @@ func TestElidedFieldWarning(t *testing.T) {
 	expected.AddOnWarn(path.New("yaml", "openshift", "fips"), common.ErrFieldElided)
 	expected.AddOnWarn(path.New("yaml", "openshift", "kernel_type"), common.ErrFieldElided)
 
-	_, _, r := in.ToIgn3_6Unvalidated(common.TranslateOptions{})
+	_, _, r := in.ToIgn3_5Unvalidated(common.TranslateOptions{})
 	assert.Equal(t, expected, r, "report mismatch")
 }
 
@@ -84,7 +84,7 @@ func TestTranslateConfig(t *testing.T) {
 				Spec: result.Spec{
 					Config: types.Config{
 						Ignition: types.Ignition{
-							Version: "3.6.0",
+							Version: "3.5.0",
 						},
 					},
 				},

--- a/config/openshift/v4_22/validate_test.go
+++ b/config/openshift/v4_22/validate_test.go
@@ -19,9 +19,9 @@ import (
 	"testing"
 
 	baseutil "github.com/coreos/butane/base/util"
-	base "github.com/coreos/butane/base/v0_7"
+	base "github.com/coreos/butane/base/v0_6"
 	"github.com/coreos/butane/config/common"
-	fcos "github.com/coreos/butane/config/fcos/v1_7"
+	fcos "github.com/coreos/butane/config/fcos/v1_6"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 	"github.com/coreos/ignition/v2/config/util"

--- a/docs/config-openshift-v4_21.md
+++ b/docs/config-openshift-v4_21.md
@@ -137,7 +137,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
         * **_needs_network_** (boolean): whether or not the device requires networking.
     * **_cex_** (object): describes the IBM Crypto Express (CEX) card configuration for the luks device.
       * **_enabled_** (boolean): whether or not to enable cex compatibility for luks. If omitted, defaults to false.
-  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Symlinks must not be present. Ownership, file modes (using `file_mode`) and directories modes (using `dir_mode`) can be specified for the tree. If not specified, ownership is not preserved and file modes are set to 0755 if the local file is executable or 0644 otherwise. File attributes can be overridden by creating a corresponding entry in the `files` section; such entries must omit `contents`.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Symlinks must not be present. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. File attributes can be overridden by creating a corresponding entry in the `files` section; such entries must omit `contents`.
     * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
     * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
 * **_systemd_** (object): describes the desired state of the systemd units.

--- a/docs/config-openshift-v4_22.md
+++ b/docs/config-openshift-v4_22.md
@@ -13,7 +13,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 <div id="spec-docs"></div>
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `openshift` for this specification.
-* **version** (string): the semantic version of the spec for this document. This document is for version `4.22.0` and generates Ignition configs with version `3.6.0`.
+* **version** (string): the semantic version of the spec for this document. This document is for version `4.22.0` and generates Ignition configs with version `3.5.0`.
 * **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
   * **name** (string): a unique [name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) for this MachineConfig resource.
   * **labels** (object): string key/value pairs to apply as [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to this MachineConfig resource. `machineconfiguration.openshift.io/role` is required.
@@ -137,17 +137,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
         * **_needs_network_** (boolean): whether or not the device requires networking.
     * **_cex_** (object): describes the IBM Crypto Express (CEX) card configuration for the luks device.
       * **_enabled_** (boolean): whether or not to enable cex compatibility for luks. If omitted, defaults to false.
-  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Symlinks must not be present. Ownership, file modes (using `file_mode`) and directories modes (using `dir_mode`) can be specified for the tree. If not specified, ownership is not preserved and file modes are set to 0755 if the local file is executable or 0644 otherwise. File attributes can be overridden by creating a corresponding entry in the `files` section; such entries must omit `contents`.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Symlinks must not be present. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. File attributes can be overridden by creating a corresponding entry in the `files` section; such entries must omit `contents`.
     * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
     * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
-    * **_file_mode_** (integer): Custom permissions to apply to files
-    * **_dir_mode_** (integer): Custom permissions to apply to directories
-    * **_user_** (object): User owner of the tree
-      * **_name_** (string): username
-      * **_id_** (integer): uid
-    * **_group_** (object): Group owner of the tree
-      * **_name_** (string): group name
-      * **_id_** (integer): gid
 * **_systemd_** (object): describes the desired state of the systemd units.
   * **_units_** (list of objects): the list of systemd units. Every unit must have a unique `name`.
     * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service").

--- a/docs/config-openshift-v4_23-exp.md
+++ b/docs/config-openshift-v4_23-exp.md
@@ -100,7 +100,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
       * **_compression_** (string): the type of compression used on the file (null or gzip). Compression cannot be used with S3.
       * **_verification_** (object): options related to the verification of the file.
         * **_hash_** (string): the hash of the file, in the form `<type>-<value>` where type is either `sha512` or `sha256`. If `compression` is specified, the hash describes the decompressed file.
-    * **_mode_** (integer): the file's permission mode. Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
+    * **_mode_** (integer): the file's permission mode. Setuid/setgid/sticky bits are supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ nav_order: 9
 
 ### Misc. changes
 
+- Roll back to Ignition spec 3.5.0 _(openshift 4.22.0)_
 - Add support for pretty error reporting, can be controlled through
   the use of `--raw-errors` (disable) and `--color`/`--colour`
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -95,7 +95,7 @@ Each version of the Butane specification corresponds to a version of the Ignitio
 | `openshift`    | 4.19.0              | 3.5.0              |
 | `openshift`    | 4.20.0              | 3.5.0              |
 | `openshift`    | 4.21.0              | 3.5.0              |
-| `openshift`    | 4.22.0              | 3.6.0              |
+| `openshift`    | 4.22.0              | 3.5.0              |
 | `openshift`    | 4.23.0-experimental | 3.7.0-experimental |
 | `r4e`          | 1.0.0               | 3.3.0              |
 | `r4e`          | 1.1.0               | 3.4.0              |

--- a/internal/doc/butane.yaml
+++ b/internal/doc/butane.yaml
@@ -39,7 +39,7 @@ mode:
       replacement: are not supported
       if:
         - variant: openshift
-          min: 4.22.0
+          min: 4.23.0
 
 append-contents-local:
   # Mention contents_local on specs that support it.
@@ -284,7 +284,7 @@ root:
                 - variant: flatcar
                   max: 1.1.0
                 - variant: openshift
-                  max: 4.20.0
+                  max: 4.22.0
                 - variant: r4e
                   max: 1.1.0
           children:
@@ -307,7 +307,7 @@ root:
                     - variant: flatcar
                       max: 1.1.0
                     - variant: openshift
-                      max: 4.20.0
+                      max: 4.22.0
                     - variant: r4e
                       max: 1.1.0
             - name: user


### PR DESCRIPTION
As a result when butane stabilized for OCP 4.22  we got into a state where OCP 4.22 renders into ignition 3.6 which the MCO will not know. To work around this for 4.22 we need to do the following.

- [x] **Update upstream (Butane) to have OCP 4.22 point to 3.5 Stable.**
- [x] Create a patch file for, RHAOS, RHEL 8 build, and request a mirror.
- [x] Create a patch for fedora, and build
- [x] Create a patch for C9s and C10s and build.