### PR TITLE
Correct partition index loop in translate.go

### DIFF
--- a/config/fcos/v1_3/translate.go
+++ b/config/fcos/v1_3/translate.go
@@ -75,10 +75,7 @@ func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Conf
 			if partition.Label != nil {
 				if *partition.Label == "root" {
 					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
-						for idx := range disk.Partitions {
-							if idx == p {
-								continue
-							}
+						for idx := p + 1; idx < len(disk.Partitions); idx++ {
 							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
 								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
 								break

--- a/config/fcos/v1_3/translate_test.go
+++ b/config/fcos/v1_3/translate_test.go
@@ -1652,6 +1652,37 @@ func TestRootPartitionConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "root last with sized partitions before",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("bios"),
+										Number:  1,
+										SizeMiB: util.IntToPtr(1),
+									},
+									{
+										Label:   util.StrToPtr("boot"),
+										Number:  3,
+										SizeMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{}, // no warning expected
+		},
 	}
 
 	for _, test := range tests {

--- a/config/fcos/v1_4/translate.go
+++ b/config/fcos/v1_4/translate.go
@@ -75,10 +75,7 @@ func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Conf
 			if partition.Label != nil {
 				if *partition.Label == "root" {
 					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
-						for idx := range disk.Partitions {
-							if idx == p {
-								continue
-							}
+						for idx := p + 1; idx < len(disk.Partitions); idx++ {
 							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
 								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
 								break

--- a/config/fcos/v1_4/translate_test.go
+++ b/config/fcos/v1_4/translate_test.go
@@ -1652,6 +1652,37 @@ func TestRootPartitionConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "root last with sized partitions before",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("bios"),
+										Number:  1,
+										SizeMiB: util.IntToPtr(1),
+									},
+									{
+										Label:   util.StrToPtr("boot"),
+										Number:  3,
+										SizeMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{}, // no warning expected
+		},
 	}
 
 	for _, test := range tests {

--- a/config/fcos/v1_5/translate.go
+++ b/config/fcos/v1_5/translate.go
@@ -76,7 +76,7 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 			if partition.Label != nil {
 				if *partition.Label == "root" {
 					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
-						for idx := range disk.Partitions {
+						for idx := p + 1; idx < len(disk.Partitions); idx++ {
 							if idx == p {
 								continue
 							}

--- a/config/fcos/v1_5/translate.go
+++ b/config/fcos/v1_5/translate.go
@@ -77,9 +77,6 @@ func (c Config) ToIgn3_4Unvalidated(options common.TranslateOptions) (types.Conf
 				if *partition.Label == "root" {
 					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
 						for idx := p + 1; idx < len(disk.Partitions); idx++ {
-							if idx == p {
-								continue
-							}
 							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
 								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
 								break

--- a/config/fcos/v1_5/translate_test.go
+++ b/config/fcos/v1_5/translate_test.go
@@ -1734,6 +1734,37 @@ func TestRootPartitionConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "root last with sized partitions before",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("bios"),
+										Number:  1,
+										SizeMiB: util.IntToPtr(1),
+									},
+									{
+										Label:   util.StrToPtr("boot"),
+										Number:  3,
+										SizeMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{}, // no warning expected
+		},
 	}
 
 	for _, test := range tests {

--- a/config/fcos/v1_6/translate.go
+++ b/config/fcos/v1_6/translate.go
@@ -76,10 +76,7 @@ func (c Config) ToIgn3_5Unvalidated(options common.TranslateOptions) (types.Conf
 			if partition.Label != nil {
 				if *partition.Label == "root" {
 					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
-						for idx := range disk.Partitions {
-							if idx == p {
-								continue
-							}
+						for idx := p + 1; idx < len(disk.Partitions); idx++ {
 							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
 								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
 								break

--- a/config/fcos/v1_6/translate_test.go
+++ b/config/fcos/v1_6/translate_test.go
@@ -1734,6 +1734,37 @@ func TestRootPartitionConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "root last with sized partitions before",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("bios"),
+										Number:  1,
+										SizeMiB: util.IntToPtr(1),
+									},
+									{
+										Label:   util.StrToPtr("boot"),
+										Number:  3,
+										SizeMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{}, // no warning expected
+		},
 	}
 
 	for _, test := range tests {

--- a/config/fcos/v1_7/translate.go
+++ b/config/fcos/v1_7/translate.go
@@ -76,10 +76,7 @@ func (c Config) ToIgn3_6Unvalidated(options common.TranslateOptions) (types.Conf
 			if partition.Label != nil {
 				if *partition.Label == "root" {
 					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
-						for idx := range disk.Partitions {
-							if idx == p {
-								continue
-							}
+						for idx := p + 1; idx < len(disk.Partitions); idx++ {
 							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
 								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
 								break

--- a/config/fcos/v1_7/translate_test.go
+++ b/config/fcos/v1_7/translate_test.go
@@ -1735,6 +1735,37 @@ func TestRootPartitionConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "root last with sized partitions before",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("bios"),
+										Number:  1,
+										SizeMiB: util.IntToPtr(1),
+									},
+									{
+										Label:   util.StrToPtr("boot"),
+										Number:  3,
+										SizeMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{}, // no warning expected
+		},
 	}
 
 	for _, test := range tests {

--- a/config/fcos/v1_8_exp/translate.go
+++ b/config/fcos/v1_8_exp/translate.go
@@ -76,10 +76,7 @@ func (c Config) ToIgn3_7Unvalidated(options common.TranslateOptions) (types.Conf
 			if partition.Label != nil {
 				if *partition.Label == "root" {
 					if partition.SizeMiB == nil || *partition.SizeMiB == 0 {
-						for idx := range disk.Partitions {
-							if idx == p {
-								continue
-							}
+						for idx := p + 1; idx < len(disk.Partitions); idx++ {
 							if disk.Partitions[idx].StartMiB == nil || *disk.Partitions[idx].StartMiB == 0 {
 								r.AddOnWarn(path.New("json", "storage", "disks", i, "partitions", p, "label"), common.ErrRootConstrained)
 								break

--- a/config/fcos/v1_8_exp/translate_test.go
+++ b/config/fcos/v1_8_exp/translate_test.go
@@ -1881,6 +1881,37 @@ func TestRootPartitionConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "root last with sized partitions before",
+			in: Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("bios"),
+										Number:  1,
+										SizeMiB: util.IntToPtr(1),
+									},
+									{
+										Label:   util.StrToPtr("boot"),
+										Number:  3,
+										SizeMiB: util.IntToPtr(2048),
+									},
+									{
+										Label:  util.StrToPtr("root"),
+										Number: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			report: report.Report{}, // no warning expected
+		},
 	}
 
 	for _, test := range tests {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,8 @@ nav_order: 9
 
 ### Bug fixes
 
+- fix root partition constraint check to only examine subsequent partitions
+
 ### Misc. changes
 
 ### Docs changes
@@ -30,6 +32,7 @@ nav_order: 9
 ### Features
 
 ### Bug fixes
+
 
 ### Misc. changes
 


### PR DESCRIPTION
currently trying to override the default sizes for the boot partitions. 

In my butain file, I have:
```
        - number: 1
          label: bios
          size_mib: 1
          type_guid: 21686148-6449-6E6F-744E-656564454649
        - number: 2
          label: efi 
          size_mib: 1024
          type_guid: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
          wipe_partition_entry: true
        - number: 3
          label: boot
          size_mib: 2048
          type_guid: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
          wipe_partition_entry: true
        - label: root
          number: 4
          wipe_partition_entry: true
          type_guid: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
```
which should be valid. root is the last partition, and all the others have a set size. currently this throws:
```
     |                  ^^^^ root partition cannot expand; it is set to fill available space but is followed by an auto-positioned partition
 122 |           number: 4
 123 |           start_mib: 0
     |
Config produced warnings and --strict was specified
```
this shoud only check the partitions after root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined root-partition constraint validation during configuration conversion by limiting the check to partitions after the `root` entry, preventing incorrect or overly broad warnings for valid disk layouts.
  * Added/extended test coverage to confirm that when `root` is the last partition (and preceding partitions have explicit, non-zero sizes), no root constraint warning is emitted.
* **Documentation**
  * Updated the release notes to reflect the root-partition constraint fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->