### PR TITLE
README: update for repository archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # Butane
 
+## This repository has been archived
+
+Butane has been merged into the [Ignition](https://github.com/coreos/ignition) repository. All future development, issues, and pull requests should be directed there.
+
+The Butane source code now lives under the [`butane/`](https://github.com/coreos/ignition/tree/main/butane) subdirectory of the Ignition repository. Starting with Ignition 2.27.0, Ignition natively accepts Butane YAML configs at boot, and the `butane` CLI is built from the Ignition source tree.
+
+For more information, see [coreos/fedora-coreos-tracker#2006](https://github.com/coreos/fedora-coreos-tracker/issues/2006).
+
+---
+
+## About Butane
+
 Butane (formerly the Fedora CoreOS Config Transpiler, FCCT) translates human readable Butane Configs
 into machine readable [Ignition](https://github.com/coreos/ignition) Configs. See the [getting
-started](docs/getting-started.md) guide for how to use Butane and the [configuration
-specifications](docs/specs.md) for everything Butane configs support.
+started](https://github.com/coreos/ignition/tree/main/butane/docs/getting-started.md) guide for how to use Butane and the [configuration
+specifications](https://github.com/coreos/ignition/tree/main/butane/docs/specs.md) for everything Butane configs support.
 
 For information on developing Butane, using it as a library, or understanding how the binaries released
-in this repository are built, see the [development docs](docs/development.md).
+are built, see the [development docs](https://github.com/coreos/ignition/tree/main/butane/docs/development.md).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,17 +4,7 @@ nav_order: 9
 
 # Release notes
 
-## Upcoming Butane 0.30.0 (unreleased)
-
-### Breaking changes
-
-### Features
-
-### Bug fixes
-
-### Misc. changes
-
-### Docs changes
+Butane 0.29.0 is the last release from this standalone repository. Butane has been merged into the [Ignition](https://github.com/coreos/ignition) repository, where all future releases will be made.
 
 ## Butane 0.29.0 (2026-06-30)
 


### PR DESCRIPTION
## Summary

Update README to indicate this repository has been archived and Butane has been merged into the Ignition repository.

## Dependencies

This PR should be merged **after** the following have landed:

- [x] FESCo approval of the [F45 Change Request](https://fedoraproject.org/wiki/Changes/IgnitionNativeButaneSupport)


## Archival steps

After merging this PR:

1.  [ ] [coreos/ignition#2235](https://github.com/coreos/ignition/pull/2235) -- Butane merge PR lands
2.  [ ] Ignition 2.27.0 release (first release with native Butane support which can happen later) 
3.  [ ] Update repo description to: `[ARCHIVED] Butane has been merged into https://github.com/coreos/ignition`
4.  [ ] Archive the repo via GitHub settings

## Tracking

- [coreos/fedora-coreos-tracker#2006](https://github.com/coreos/fedora-coreos-tracker/issues/2006)