### PR TITLE
base: validate local ignition config files under ignition.config

### DIFF
--- a/base/v0_7/translate.go
+++ b/base/v0_7/translate.go
@@ -112,7 +112,7 @@ func (c Config) ToIgn3_6Unvalidated(options common.TranslateOptions) (types.Conf
 
 func translateIgnition(from Ignition, options common.TranslateOptions) (to types.Ignition, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
-	tr.AddCustomTranslator(translateResource)
+	tr.AddCustomTranslator(translateResourceForIgnition)
 	to.Version = types.MaxVersion.String()
 	tm, r = translate.Prefixed(tr, "config", &from.Config, &to.Config)
 	translate.MergeP(tr, tm, &r, "proxy", &from.Proxy, &to.Proxy)
@@ -135,6 +135,18 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 }
 
 func translateResource(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
+	return translateResourceInternal(from, options, false)
+}
+
+// translateResourceForIgnition is like translateResource but additionally
+// validates the contents of local files as Ignition configs, since the
+// resources under ignition.config.merge/replace are themselves Ignition
+// configs.
+func translateResourceForIgnition(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
+	return translateResourceInternal(from, options, true)
+}
+
+func translateResourceInternal(from Resource, options common.TranslateOptions, validateIgnitionConfig bool) (to types.Resource, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
 	translate.MergeP2(tr, tm, &r, "http_headers", &from.HTTPHeaders, "httpHeaders", &to.HTTPHeaders)
@@ -148,9 +160,11 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			r.AddOnError(c, err)
 			return
 		}
-		// Validating the contents of the local file from here since there is no way to
-		// get both the filename and filedirectory in the Validate context
-		if strings.HasPrefix(c.String(), "$.ignition.config") {
+		// Validate the contents of the local file from here since there is no
+		// way to get both the filename and filedirectory in the Validate
+		// context. Local files under ignition.config.merge/replace are Ignition
+		// configs and must be validated as such.
+		if validateIgnitionConfig {
 			rp, err := ValidateIgnitionConfig(c, contents)
 			r.Merge(rp)
 			if err != nil {

--- a/base/v0_7/translate_test.go
+++ b/base/v0_7/translate_test.go
@@ -1992,6 +1992,75 @@ func TestTranslateIgnition(t *testing.T) {
 	}
 }
 
+// TestTranslateIgnitionLocalValidation verifies that local files referenced
+// via ignition.config.merge/replace are validated as Ignition configs during
+// translation (regression test for issue #724).
+func TestTranslateIgnitionLocalValidation(t *testing.T) {
+	filesDir := t.TempDir()
+
+	// A malformed Ignition config (invalid YAML) referenced via a local file.
+	malformed := "this: is: not: valid: ignition: config"
+	// A well-formed Ignition config referenced via a local file.
+	valid := `{"ignition": {"version": "3.6.0"}}`
+
+	if err := os.WriteFile(filepath.Join(filesDir, "malformed"), []byte(malformed), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filesDir, "valid"), []byte(valid), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		in        Ignition
+		expectErr bool
+	}{
+		{
+			name: "malformed local config under merge is rejected",
+			in: Ignition{
+				Config: IgnitionConfig{
+					Merge: []Resource{
+						{Local: util.StrToPtr("malformed")},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid local config under merge is accepted",
+			in: Ignition{
+				Config: IgnitionConfig{
+					Merge: []Resource{
+						{Local: util.StrToPtr("valid")},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "malformed local config under replace is rejected",
+			in: Ignition{
+				Config: IgnitionConfig{
+					Replace: Resource{Local: util.StrToPtr("malformed")},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := translateIgnition(test.in, common.TranslateOptions{FilesDir: filesDir})
+			r = confutil.TranslateReportPaths(r, translations)
+			if test.expectErr {
+				assert.NotEqual(t, report.Report{}, r, "expected a validation error for malformed local ignition config")
+			} else {
+				assert.Equal(t, report.Report{}, r, "unexpected validation error for valid local ignition config")
+			}
+		})
+	}
+}
+
 // TestTranslateKernelArguments tests translating the butane kernel_arguments.{should_exist,should_not_exist}.[i] entries to
 // ignition kernelArguments.{shouldExist,shouldNotExist}.[i] entries.
 //

--- a/base/v0_8_exp/translate.go
+++ b/base/v0_8_exp/translate.go
@@ -116,7 +116,7 @@ func (c Config) ToIgn3_7Unvalidated(options common.TranslateOptions) (types.Conf
 
 func translateIgnition(from Ignition, options common.TranslateOptions) (to types.Ignition, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
-	tr.AddCustomTranslator(translateResource)
+	tr.AddCustomTranslator(translateResourceForIgnition)
 	to.Version = types.MaxVersion.String()
 	tm, r = translate.Prefixed(tr, "config", &from.Config, &to.Config)
 	translate.MergeP(tr, tm, &r, "proxy", &from.Proxy, &to.Proxy)
@@ -139,6 +139,18 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 }
 
 func translateResource(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
+	return translateResourceInternal(from, options, false)
+}
+
+// translateResourceForIgnition is like translateResource but additionally
+// validates the contents of local files as Ignition configs, since the
+// resources under ignition.config.merge/replace are themselves Ignition
+// configs.
+func translateResourceForIgnition(from Resource, options common.TranslateOptions) (to types.Resource, tm translate.TranslationSet, r report.Report) {
+	return translateResourceInternal(from, options, true)
+}
+
+func translateResourceInternal(from Resource, options common.TranslateOptions, validateIgnitionConfig bool) (to types.Resource, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
 	translate.MergeP2(tr, tm, &r, "http_headers", &from.HTTPHeaders, "httpHeaders", &to.HTTPHeaders)
@@ -152,9 +164,11 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			r.AddOnError(c, err)
 			return
 		}
-		// Validating the contents of the local file from here since there is no way to
-		// get both the filename and filedirectory in the Validate context
-		if strings.HasPrefix(c.String(), "$.ignition.config") {
+		// Validate the contents of the local file from here since there is no
+		// way to get both the filename and filedirectory in the Validate
+		// context. Local files under ignition.config.merge/replace are Ignition
+		// configs and must be validated as such.
+		if validateIgnitionConfig {
 			rp, err := ValidateIgnitionConfig(c, contents)
 			r.Merge(rp)
 			if err != nil {

--- a/base/v0_8_exp/translate_test.go
+++ b/base/v0_8_exp/translate_test.go
@@ -1992,6 +1992,75 @@ func TestTranslateIgnition(t *testing.T) {
 	}
 }
 
+// TestTranslateIgnitionLocalValidation verifies that local files referenced
+// via ignition.config.merge/replace are validated as Ignition configs during
+// translation (regression test for issue #724).
+func TestTranslateIgnitionLocalValidation(t *testing.T) {
+	filesDir := t.TempDir()
+
+	// A malformed Ignition config (invalid YAML) referenced via a local file.
+	malformed := "this: is: not: valid: ignition: config"
+	// A well-formed Ignition config (empty JSON object) referenced via a local file.
+	valid := `{"ignition": {"version": "3.7.0-experimental"}}`
+
+	if err := os.WriteFile(filepath.Join(filesDir, "malformed"), []byte(malformed), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filesDir, "valid"), []byte(valid), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		in        Ignition
+		expectErr bool
+	}{
+		{
+			name: "malformed local config under merge is rejected",
+			in: Ignition{
+				Config: IgnitionConfig{
+					Merge: []Resource{
+						{Local: util.StrToPtr("malformed")},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid local config under merge is accepted",
+			in: Ignition{
+				Config: IgnitionConfig{
+					Merge: []Resource{
+						{Local: util.StrToPtr("valid")},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "malformed local config under replace is rejected",
+			in: Ignition{
+				Config: IgnitionConfig{
+					Replace: Resource{Local: util.StrToPtr("malformed")},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, translations, r := translateIgnition(test.in, common.TranslateOptions{FilesDir: filesDir})
+			r = confutil.TranslateReportPaths(r, translations)
+			if test.expectErr {
+				assert.NotEqual(t, report.Report{}, r, "expected a validation error for malformed local ignition config")
+			} else {
+				assert.Equal(t, report.Report{}, r, "unexpected validation error for valid local ignition config")
+			}
+		})
+	}
+}
+
 // TestTranslateKernelArguments tests translating the butane kernel_arguments.{should_exist,should_not_exist}.[i] entries to
 // ignition kernelArguments.{shouldExist,shouldNotExist}.[i] entries.
 //


### PR DESCRIPTION
## Summary

`translateResource` contained dead validation code: the `strings.HasPrefix(c.String(), "$.ignition.config")` guard at `base/v0_8_exp/translate.go:157` (and `base/v0_7/translate.go:153`) is always `false`, because `c` is `path.New("yaml", "local")` whose `String()` is `$.local`, never `$.ignition.config`. As a result, local files referenced via `ignition.config.merge` / `ignition.config.replace` were never validated as Ignition configs, and malformed configs passed through silently (issue #724).

## Fix

Refactor `translateResource` into an internal helper `translateResourceInternal` with a `validateIgnitionConfig bool` parameter. Register `translateResourceForIgnition` (which passes `true`) for the `ignition.config` translation path, while the existing `translateResource` (passing `false`) continues to serve other local resources such as file contents, where the content is not an Ignition config and must not be validated as one.

The local file is now validated via `ValidateIgnitionConfig` during translation, where `options.FilesDir` is available (validation has no access to `FilesDir`, which is why the check belongs in the translation phase).

## Test plan

- Added `TestTranslateIgnitionLocalValidation` to both `base/v0_7` and `base/v0_8_exp` translate tests, covering:
  - malformed local config under `merge` → rejected
  - valid local config under `merge` → accepted
  - malformed local config under `replace` → rejected

All existing tests in `base/v0_7` and `base/v0_8_exp` continue to pass.

Fixes: #724


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local Ignition configuration files referenced by `merge` and `replace` are now validated as Ignition configs.
  * Malformed nested configurations produce translation errors, while valid configurations continue to translate successfully.

* **Tests**
  * Added coverage for valid and invalid local Ignition configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->