### PR TITLE
main: use friendly filename in stdin read error

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -32,6 +32,22 @@ func fail(format string, args ...interface{}) {
 	os.Exit(1)
 }
 
+func readInput(input string) ([]byte, string, error) {
+	filename := "<stdin>"
+	reader := io.Reader(os.Stdin)
+	if input != "" {
+		f, err := os.Open(input)
+		if err != nil {
+			return nil, input, err
+		}
+		defer f.Close()
+		reader = f
+		filename = input
+	}
+	data, err := io.ReadAll(reader)
+	return data, filename, err
+}
+
 func isCharDevice(f *os.File) bool {
 	stat, err := f.Stat()
 	if err != nil {
@@ -110,21 +126,9 @@ func main() {
 		os.Exit(0)
 	}
 
-	infile := os.Stdin
-	filename := "<stdin>"
-	if input != "" {
-		var err error
-		infile, err = os.Open(input)
-		if err != nil {
-			fail("failed to open %s: %v\n", input, err)
-		}
-		defer infile.Close()
-		filename = input
-	}
-
-	dataIn, err := io.ReadAll(infile)
+	dataIn, filename, err := readInput(input)
 	if err != nil {
-		fail("failed to read %s: %v\n", infile.Name(), err)
+		fail("failed to read %s: %v\n", filename, err)
 	}
 
 	dataOut, r, err := config.TranslateBytes(dataIn, options)

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -1,0 +1,128 @@
+// Copyright 2024 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T) (input string, cleanup func())
+		wantData []byte
+		wantErr  bool
+	}{
+		{
+			name: "stdin",
+			setup: func(t *testing.T) (string, func()) {
+				content := []byte("hello from stdin")
+				orig := os.Stdin
+				tmp, err := os.CreateTemp("", "butane-stdin")
+				if err != nil {
+					t.Fatalf("failed to create temp file: %v", err)
+				}
+				if _, err := tmp.Write(content); err != nil {
+					t.Fatalf("failed to write temp file: %v", err)
+				}
+				if _, err := tmp.Seek(0, 0); err != nil {
+					t.Fatalf("failed to seek temp file: %v", err)
+				}
+				os.Stdin = tmp
+				return "", func() {
+					os.Stdin = orig
+					tmp.Close()
+					os.Remove(tmp.Name())
+				}
+			},
+			wantData: []byte("hello from stdin"),
+			wantErr:  false,
+		},
+		{
+			name: "empty stdin",
+			setup: func(t *testing.T) (string, func()) {
+				orig := os.Stdin
+				tmp, err := os.CreateTemp("", "butane-stdin-empty")
+				if err != nil {
+					t.Fatalf("failed to create temp file: %v", err)
+				}
+				if _, err := tmp.Seek(0, 0); err != nil {
+					t.Fatalf("failed to seek temp file: %v", err)
+				}
+				os.Stdin = tmp
+				return "", func() {
+					os.Stdin = orig
+					tmp.Close()
+					os.Remove(tmp.Name())
+				}
+			},
+			wantData: []byte{},
+			wantErr:  false,
+		},
+		{
+			name: "file",
+			setup: func(t *testing.T) (string, func()) {
+				dir := t.TempDir()
+				path := filepath.Join(dir, "input.bu")
+				content := []byte("variant: fcos")
+				if err := os.WriteFile(path, content, 0644); err != nil {
+					t.Fatalf("failed to write file: %v", err)
+				}
+				return path, func() {}
+			},
+			wantData: []byte("variant: fcos"),
+			wantErr:  false,
+		},
+		{
+			name: "missing file",
+			setup: func(t *testing.T) (string, func()) {
+				missing := filepath.Join(t.TempDir(), "does-not-exist")
+				return missing, func() {}
+			},
+			wantData: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, cleanup := tt.setup(t)
+			defer cleanup()
+
+			data, filename, err := readInput(input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if string(data) != string(tt.wantData) {
+				t.Errorf("expected data %q, got %q", tt.wantData, data)
+			}
+
+			wantName := "<stdin>"
+			if input != "" {
+				wantName = input
+			}
+			if filename != wantName {
+				t.Errorf("expected filename %q, got %q", wantName, filename)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

In `internal/main.go`, the `io.ReadAll` failure path formatted its error with `infile.Name()`, which returns `/dev/stdin` on Linux instead of the friendly `<stdin>` label used everywhere else in the function (and in the `TranslateBytes` report path).

## Changes

Extracted the input-reading logic into a `readInput(input string) ([]byte, string, error)` helper. It returns the friendly filename (`<stdin>` when reading from stdin, the real path when `--input`/a positional file is given) so the read error message and the translation report stay consistent.

`internal/main.go` line 127 (now in `readInput`):

```go
fail("failed to read %s: %v\n", filename, err)
```

`filename` is now `<stdin>` for the stdin case instead of `/dev/stdin`.

## Verification

Added `internal/main_test.go` covering `readInput`:
- reading from stdin yields content and the `<stdin>` filename
- reading a real file yields content and the real path as filename
- a missing file returns an error with the requested path as filename

`./test` passes (gofmt, go vet, full test suite, doc validation).

Before: `failed to read /dev/stdin: <error>`
After:  `failed to read <stdin>: <error>`

Fixes: #726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of input from standard input and specified files.
  * Added clearer error handling for missing or unreadable files.

* **Tests**
  * Added coverage for standard input, file input, missing files, returned filenames, and failed reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->