### PR TITLE
docs: add file append and overwrite examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -149,7 +149,7 @@ storage:
       mode: 0644
 ```
 
-Use ordinary `contents` when Butane should write the complete contents of a new or existing regular file. Use `append` with the safe default `overwrite: false` when the existing contents should be preserved and one or more fragments added to the end. This example appends a rule to a drop-in under `/etc/sudoers.d/` instead of modifying `/etc/sudoers` directly.
+Use ordinary `contents` when Butane should write the complete contents of a new or existing regular file. Use `append` with the safe default `overwrite: false` when the existing contents should be preserved and one or more fragments added to the end. For sudoers rules, prefer a drop-in under `/etc/sudoers.d/` over modifying `/etc/sudoers` directly; this example appends to `/etc/sudoers.d/core`.
 
 <!-- butane-config -->
 ```yaml

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -149,6 +149,38 @@ storage:
       mode: 0644
 ```
 
+Use ordinary `contents` when Butane should write the complete contents of a new or existing regular file. Use `append` with the safe default `overwrite: false` when the existing contents should be preserved and one or more fragments added to the end. This example appends a rule to a drop-in under `/etc/sudoers.d/` instead of modifying `/etc/sudoers` directly.
+
+<!-- butane-config -->
+```yaml
+variant: fcos
+version: 1.7.0
+storage:
+  files:
+    - path: /etc/sudoers.d/core
+      mode: 0440
+      overwrite: false
+      append:
+        - inline: |
+            core ALL=(ALL) NOPASSWD: /usr/bin/podman
+```
+
+Use `overwrite: true` with `contents` when any existing filesystem node at the path should be removed and replaced. This example replaces anything at `/etc/example.conf` with a regular file containing the specified settings.
+
+<!-- butane-config -->
+```yaml
+variant: fcos
+version: 1.7.0
+storage:
+  files:
+    - path: /etc/example.conf
+      overwrite: true
+      contents:
+        inline: |
+          enabled = true
+      mode: 0644
+```
+
 ### Directory trees
 
 Consider a directory tree at `~/conf/tree` on the system running Butane:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -149,7 +149,22 @@ storage:
       mode: 0644
 ```
 
-Use ordinary `contents` when Butane should write the complete contents of a new or existing regular file. Use `append` with the safe default `overwrite: false` when the existing contents should be preserved and one or more fragments added to the end. For sudoers rules, prefer a drop-in under `/etc/sudoers.d/` over modifying `/etc/sudoers` directly; this example appends to `/etc/sudoers.d/core`.
+Use ordinary `contents` when Butane should write the complete contents of a new or existing regular file. Use `append` with the safe default `overwrite: false` when the existing contents should be preserved and one or more fragments added to the end. This example adds a sudoers rule to the end of the shipped `/etc/sudoers`.
+
+<!-- butane-config -->
+```yaml
+variant: fcos
+version: 1.7.0
+storage:
+  files:
+    - path: /etc/sudoers
+      overwrite: false
+      append:
+        - inline: |
+            core ALL=(ALL) NOPASSWD: /usr/bin/podman
+```
+
+For sudoers rules specifically, a drop-in under `/etc/sudoers.d/` is usually preferable to appending to `/etc/sudoers`, since it survives updates to the shipped file. The same `append` semantics apply, and a new drop-in needs an explicit `mode`:
 
 <!-- butane-config -->
 ```yaml


### PR DESCRIPTION
## Summary

- add a minimal file `append` example using explicit `overwrite: false`
- add a distinct `contents` example using `overwrite: true`
- explain when each behavior is appropriate

## Testing

- both new snippets pass the built Butane binary with `--check --strict`
- `git diff --check`

The full `./test` suite reached the Go tests but could not complete in the managed environment because an existing Unix-socket fixture was denied permission.

Closes #499.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added examples for appending content to existing files.
  * Documented creating sudoers drop-ins with explicit file permissions.
  * Added an example for replacing existing file contents using overwrite options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->