### PR TITLE
openshift/v4_23_exp validate: report CEX kernel arg error once

### DIFF
--- a/config/openshift/v4_23_exp/validate.go
+++ b/config/openshift/v4_23_exp/validate.go
@@ -51,10 +51,10 @@ func (os OpenShift) Validate(c path.ContextPath) (r report.Report) {
 // See: https://github.com/coreos/butane/issues/611
 // See: https://github.com/coreos/butane/issues/613
 func (conf Config) Validate(c path.ContextPath) (r report.Report) {
-	if util.IsTrue(conf.BootDevice.Luks.Cex.Enabled) && !slices.Contains(conf.OpenShift.KernelArguments, "rd.luks.key=/etc/luks/cex.key") {
-		r.AddOnError(c.Append("openshift", "kernel_arguments"), common.ErrMissingKernelArgumentCex)
-	}
 	cex := false
+	if util.IsTrue(conf.BootDevice.Luks.Cex.Enabled) {
+		cex = true
+	}
 	for _, l := range conf.Storage.Luks {
 		if util.IsTrue(l.Cex.Enabled) && l.Name == "root" {
 			cex = true

--- a/config/openshift/v4_23_exp/validate_test.go
+++ b/config/openshift/v4_23_exp/validate_test.go
@@ -230,6 +230,42 @@ func TestValidateConfig(t *testing.T) {
 			common.ErrMissingKernelArgumentCex,
 			path.New("yaml", "openshift", "kernel_arguments"),
 		},
+		{
+			// both boot_device CEX and a root storage.luks CEX entry set;
+			// the missing kernel argument must be reported exactly once
+			Config{
+				Config: fcos.Config{
+					BootDevice: fcos.BootDevice{
+						Layout: util.StrToPtr("s390x-eckd"),
+						Luks: fcos.BootDeviceLuks{
+							Device: util.StrToPtr("/dev/dasda"),
+							Cex: base.Cex{
+								Enabled: util.BoolToPtr(true),
+							},
+						},
+					},
+					Config: base.Config{
+						Storage: base.Storage{
+							Luks: []base.Luks{
+								{
+									Name:   "root",
+									Label:  util.StrToPtr("luks-root"),
+									Device: util.StrToPtr("/dev/disk/by-label/root"),
+									Cex: base.Cex{
+										Enabled: util.BoolToPtr(true),
+									},
+								},
+							},
+						},
+					},
+				},
+				OpenShift: OpenShift{
+					KernelArguments: []string{},
+				},
+			},
+			common.ErrMissingKernelArgumentCex,
+			path.New("yaml", "openshift", "kernel_arguments"),
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
## Summary

`Config.Validate` in `config/openshift/v4_23_exp/validate.go` emitted `ErrMissingKernelArgumentCex` twice at `$.openshift.kernel_arguments` when both `boot_device.luks.cex.enabled: true` and a `storage.luks` root entry with `cex.enabled: true` were set.

Two independent `if`-blocks each called `r.AddOnError(c.Append("openshift", "kernel_arguments"), common.ErrMissingKernelArgumentCex)` when the `rd.luks.key=/etc/luks/cex.key` kernel argument was absent, so both fired and the identical error was reported twice.

## Fix

Consolidate the two checks into a single `cex` flag (set when either the boot-device CEX is enabled or any root `storage.luks` entry has CEX enabled) and emit the error exactly once when the flag is set and the kernel argument is missing. Behavior and error path are unchanged.

## Test plan

- Added a `TestValidateConfig` case that sets both CEX sources and an empty kernel argument list, asserting exactly one `ErrMissingKernelArgumentCex` at `$.openshift.kernel_arguments`.
- Verified the new test fails on the old code (two entries) and passes on the fixed code (one entry).
- `./test` (gofmt, go vet, go test `./...`, doc validation) passes.

Fixes #731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for configurations that enable CEX on both the boot device and encrypted root storage.
  * Ensured missing OpenShift kernel arguments produce a single, accurate validation error.

* **Tests**
  * Added coverage for combined boot-device and root-storage CEX configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->